### PR TITLE
feat: N:M 테이블에 복합키 대신 pk 추가

### DIFF
--- a/src/main/java/com/sprint/monew/domain/article/articleinterest/ArticleInterest.java
+++ b/src/main/java/com/sprint/monew/domain/article/articleinterest/ArticleInterest.java
@@ -2,51 +2,50 @@ package com.sprint.monew.domain.article.articleinterest;
 
 import com.sprint.monew.domain.article.Article;
 import com.sprint.monew.domain.interest.Interest;
-import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 @Getter
 @Entity
-@Table(name = "articles_interests")
+@Table(name = "articles_interests", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"article_id", "interest_id"})
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ArticleInterest {
 
-  @EmbeddedId
-  private ArticleInterestKey id;
+  @Id
+  private UUID id;
 
-  @MapsId("articleId")
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "article_id")
   private Article article;
 
-  @MapsId("interestId")
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "interest_id")
   private Interest interest;
 
   @Builder(access = AccessLevel.PRIVATE)
-  private ArticleInterest(ArticleInterestKey id, Article article, Interest interest) {
-    this.id = id;
+  private ArticleInterest(Article article, Interest interest) {
+    this.id = UUID.randomUUID();
     this.article = article;
     this.interest = interest;
   }
 
   public static ArticleInterest create(Article article, Interest interest) {
-    ArticleInterestKey articleInterestKey = new ArticleInterestKey(article.getId(),
-        interest.getId());
     return ArticleInterest.builder()
         .article(article)
         .interest(interest)
-        .id(articleInterestKey)
         .build();
   }
 }

--- a/src/main/java/com/sprint/monew/domain/article/articleview/ArticleView.java
+++ b/src/main/java/com/sprint/monew/domain/article/articleview/ArticleView.java
@@ -3,14 +3,16 @@ package com.sprint.monew.domain.article.articleview;
 import com.sprint.monew.domain.article.Article;
 import com.sprint.monew.domain.user.User;
 import jakarta.persistence.Column;
-import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
 import java.time.Instant;
+import java.util.UUID;
+
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,19 +21,19 @@ import org.springframework.data.annotation.CreatedDate;
 
 @Getter
 @Entity
-@Table(name = "articles_views")
+@Table(name = "articles_views", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "article_id"})
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ArticleView {
 
-  @EmbeddedId
-  private ArticleViewKey id;
+  @Id
+  private UUID id;
 
-  @MapsId("userId")
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
   private User user;
 
-  @MapsId("articleId")
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "article_id")
   private Article article;
@@ -41,16 +43,14 @@ public class ArticleView {
   private Instant createdAt;
 
   @Builder(access = AccessLevel.PRIVATE)
-  private ArticleView(ArticleViewKey id, User user, Article article) {
-    this.id = id;
+  private ArticleView(User user, Article article) {
+    this.id = UUID.randomUUID();
     this.user = user;
     this.article = article;
   }
 
   public static ArticleView create(User user, Article article) {
-    ArticleViewKey key = new ArticleViewKey(user.getId(), article.getId());
     return ArticleView.builder()
-        .id(key)
         .user(user)
         .article(article)
         .build();

--- a/src/main/java/com/sprint/monew/domain/interest/userinterest/UserInterest.java
+++ b/src/main/java/com/sprint/monew/domain/interest/userinterest/UserInterest.java
@@ -3,41 +3,46 @@ package com.sprint.monew.domain.interest.userinterest;
 import com.sprint.monew.domain.interest.Interest;
 import com.sprint.monew.domain.user.User;
 import jakarta.persistence.Column;
-import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
 import java.time.Instant;
-import lombok.AllArgsConstructor;
+import java.util.UUID;
+
+import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "users_interests")
+@Table(name = "users_interests", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "interest_id"})
+})
 @NoArgsConstructor
 public class UserInterest {
 
-  @EmbeddedId
-  private UserInterestKey id;
+  @Id
+  private UUID id;
 
   @MapsId("userId")
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id")
+  @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
   @MapsId("interestId")
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "interest_id")
+  @JoinColumn(name = "interest_id", nullable = false)
   private Interest interest;
 
   @Column(nullable = false)
   private Instant createdAt;
 
   public UserInterest(User user, Interest interest) {
+    this.id = UUID.randomUUID();
     this.user = user;
     this.interest = interest;
     this.createdAt = Instant.now();

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,6 +1,6 @@
 CREATE TABLE "users"
 (
-    "id"         UUID         PRIMARY KEY,
+    "id"         UUID PRIMARY KEY,
     "email"      VARCHAR(255) NOT NULL UNIQUE,
     "nickname"   VARCHAR(255) NOT NULL,
     "password"   VARCHAR(255) NOT NULL,
@@ -10,7 +10,7 @@ CREATE TABLE "users"
 
 CREATE TABLE "articles"
 (
-    "id"           UUID          PRIMARY KEY,
+    "id"           UUID PRIMARY KEY,
     "source"       VARCHAR(255)  NOT NULL,
     "source_url"   VARCHAR(2048) NOT NULL UNIQUE,
     "title"        VARCHAR(255)  NOT NULL,
@@ -21,7 +21,7 @@ CREATE TABLE "articles"
 
 CREATE TABLE "comments"
 (
-    "id"         UUID         PRIMARY KEY,
+    "id"         UUID PRIMARY KEY,
     "user_id"    UUID         NOT NULL,
     "article_id" UUID         NOT NULL,
     "content"    VARCHAR(255) NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE "comments"
 
 CREATE TABLE "notifications"
 (
-    "id"            UUID         PRIMARY KEY,
+    "id"            UUID PRIMARY KEY,
     "user_id"       UUID         NOT NULL,
     "resource_id"   UUID         NOT NULL,
     "resource_type" VARCHAR(50)  NOT NULL,
@@ -43,31 +43,33 @@ CREATE TABLE "notifications"
 
 CREATE TABLE "interests"
 (
-    "id"       UUID        PRIMARY KEY,
-    "name"     VARCHAR(50) NOT NULL UNIQUE,
-    "keywords" JSONB      NULL,
-    "created_at"  TIMESTAMPTZ NOT NULL DEFAULT now()
+    "id"         UUID PRIMARY KEY,
+    "name"       VARCHAR(50) NOT NULL UNIQUE,
+    "keywords"   JSONB       NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 CREATE TABLE "users_interests"
 (
+    "id"          UUID PRIMARY KEY,
     "user_id"     UUID,
     "interest_id" UUID,
     "created_at"  TIMESTAMPTZ NOT NULL DEFAULT now(),
-    PRIMARY KEY (user_id, interest_id)
+    UNIQUE (user_id, interest_id)
 );
 
 CREATE TABLE "articles_views"
 (
+    "id"         UUID PRIMARY KEY,
     "user_id"    UUID,
     "article_id" UUID,
     "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
-    PRIMARY KEY (user_id, article_id)
+    UNIQUE (user_id, article_id)
 );
 
 CREATE TABLE "likes"
 (
-    "id"         UUID        PRIMARY KEY,
+    "id"         UUID PRIMARY KEY,
     "comment_id" UUID        NOT NULL,
     "user_id"    UUID        NOT NULL,
     "created_at" TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -75,9 +77,10 @@ CREATE TABLE "likes"
 
 CREATE TABLE "articles_interests"
 (
+    "id"          UUID PRIMARY KEY,
     "article_id"  UUID NOT NULL,
     "interest_id" UUID NOT NULL,
-    Primary Key (article_id, interest_id)
+    UNIQUE (article_id, interest_id)
 );
 
 ALTER TABLE "comments"

--- a/src/main/resources/seed.sql
+++ b/src/main/resources/seed.sql
@@ -22,21 +22,23 @@ WITH
     i1 AS (SELECT id AS interest_id FROM interests WHERE name = '기술'),
     i2 AS (SELECT id AS interest_id FROM interests WHERE name = '건강')
 
-INSERT INTO "users_interests" ("user_id", "interest_id")
-SELECT u1.user_id, i1.interest_id FROM u1, i1
+INSERT INTO "users_interests" ("user_id", "interest_id", "created_at")
+SELECT u1.user_id, i1.interest_id, now() FROM u1, i1
 UNION
-SELECT u2.user_id, i2.interest_id FROM u2, i2;
+SELECT u2.user_id, i2.interest_id, now() FROM u2, i2;
 
 -- ARTICLES (기사)
 INSERT INTO "articles" ("id", "source", "source_url", "title", "summary", "publish_date")
 VALUES
-    (gen_random_uuid(), '테크뉴스', 'https://site.com/ai', '인공지능의 미래', 'AI가 바꾸는 세상에 대한 이야기', now()),
-    (gen_random_uuid(), '건강매거진', 'https://site.com/health', '건강하게 사는 법', '건강을 유지하는 실용적인 팁', now());
+    (gen_random_uuid(), 'NAVER', 'https://site.com/ai', '인공지능의 미래', 'AI가 바꾸는 세상에 대한 이야기', now()),
+    (gen_random_uuid(), 'CHOSUN', 'https://site.com/health', '건강하게 사는 법', '건강을 유지하는 실용적인 팁', now());
 
 -- ARTICLES_INTERESTS (기사-관심사 연결)
 WITH
     a1 AS (SELECT id AS article_id FROM articles WHERE title = '인공지능의 미래'),
-    a2 AS (SELECT id AS article_id FROM articles WHERE title = '건강하게 사는 법')
+    a2 AS (SELECT id AS article_id FROM articles WHERE title = '건강하게 사는 법'),
+    i1 AS (SELECT id AS interest_id FROM interests WHERE name = '기술'),
+    i2 AS (SELECT id AS interest_id FROM interests WHERE name = '건강')
 
 INSERT INTO "articles_interests" ("article_id", "interest_id")
 SELECT a1.article_id, i1.interest_id FROM a1, i1
@@ -70,10 +72,10 @@ WITH
     a1 AS (SELECT id AS article_id FROM articles WHERE title = '인공지능의 미래'),
     a2 AS (SELECT id AS article_id FROM articles WHERE title = '건강하게 사는 법')
 
-INSERT INTO "articles_views" ("user_id", "article_id")
-SELECT u1.user_id, a1.article_id FROM u1, a1
+INSERT INTO "articles_views" ("user_id", "article_id", "created_at")
+SELECT u1.user_id, a1.article_id, now() FROM u1, a1
 UNION
-SELECT u2.user_id, a2.article_id FROM u2, a2;
+SELECT u2.user_id, a2.article_id, now() FROM u2, a2;
 
 -- NOTIFICATIONS (알림)
 WITH
@@ -82,7 +84,11 @@ WITH
     c1 AS (SELECT id AS resource_id FROM comments WHERE content = '정말 흥미로운 기사네요!'),
     c2 AS (SELECT id AS resource_id FROM comments WHERE content = '도움이 많이 됐어요!')
 
-INSERT INTO "notifications" ("id", "user_id", "resource_id", "resource_type", "content")
-SELECT gen_random_uuid(), u1.user_id, c1.resource_id, 'comment', '누군가 내 댓글에 좋아요를 눌렀어요.' FROM u1, c1
+INSERT INTO "notifications" ("id", "user_id", "resource_id", "resource_type", "content", "confirmed", "created_at", "updated_at")
+SELECT gen_random_uuid(), u1.user_id, c1.resource_id, 'COMMENT', '누군가 내 댓글에 좋아요를 눌렀어요.', false, now(), now() FROM u1, c1
 UNION
-SELECT gen_random_uuid(), u2.user_id, c2.resource_id, 'comment', '새로운 댓글이 달렸어요.' FROM u2, c2;
+SELECT gen_random_uuid(), u2.user_id, c2.resource_id, 'COMMENT', '새로운 댓글이 달렸어요.', false, now(), now() FROM u2, c2;
+
+SELECT conname, pg_get_constraintdef(c.oid)
+FROM pg_constraint c
+WHERE conrelid = 'notifications'::regclass;


### PR DESCRIPTION
## 🛰️ Issue Number
- #76 
## 🪐 작업 내용
- `ArticleInterest`, `ArticleView`, `UserInterest`의 복합키 제거 > 유니크로 변경
- 복합키에서 UUID 형식의 pk로 변경
## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
