### PR TITLE
feat: 활동내역 쿼리 조회 및 MongoDB 조회 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	//implementation 'org.springframework.ai:spring-ai-starter-vector-store-mongodb-atlas'
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
 	implementation "io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0"
 

--- a/src/main/java/com/sprint/monew/domain/activity/UserActivityController.java
+++ b/src/main/java/com/sprint/monew/domain/activity/UserActivityController.java
@@ -19,10 +19,26 @@ public class UserActivityController {
     private final UserActivityService userActivityService;
 
     @GetMapping("/{userId}")
+    public ResponseEntity<UserActivityDto> getUserActivityFromMongo(
+            @PathVariable UUID userId,
+            @RequestHeader(name = "Monew-Request-User-ID", required = false) UUID headerUserId
+    ) {
+        return ResponseEntity.ok(userActivityService.getUserActivityFromMongo(userId));
+    }
+
+    @GetMapping("/{userId}/query")
     public ResponseEntity<UserActivityDto> getUserActivity(
             @PathVariable UUID userId,
             @RequestHeader(name = "Monew-Request-User-ID", required = false) UUID headerUserId
     ) {
         return ResponseEntity.ok(userActivityService.getUserActivity(userId));
+    }
+
+    @GetMapping("/{userId}/save")
+    public ResponseEntity<UserActivityDto> saveUserActivityToMongo(
+            @PathVariable UUID userId,
+            @RequestHeader(name = "Monew-Request-User-ID", required = false) UUID headerUserId
+    ) {
+        return ResponseEntity.ok(userActivityService.saveUserActivityToMongo(userId));
     }
 }

--- a/src/main/java/com/sprint/monew/domain/activity/UserActivityController.java
+++ b/src/main/java/com/sprint/monew/domain/activity/UserActivityController.java
@@ -21,7 +21,7 @@ public class UserActivityController {
     @GetMapping("/{userId}")
     public ResponseEntity<UserActivityDto> getUserActivity(
             @PathVariable UUID userId,
-            @RequestHeader("Monew-Request-User-ID") UUID headerUserId
+            @RequestHeader(name = "Monew-Request-User-ID", required = false) UUID headerUserId
     ) {
         return ResponseEntity.ok(userActivityService.getUserActivity(userId));
     }

--- a/src/main/java/com/sprint/monew/domain/activity/UserActivityDocument.java
+++ b/src/main/java/com/sprint/monew/domain/activity/UserActivityDocument.java
@@ -36,11 +36,11 @@ public class UserActivityDocument {
     private List<SubscriptionDto> subscriptions = new ArrayList<>();
 
     @Builder.Default
-    private List<CommentDto> recentComments = new ArrayList<>();
+    private List<CommentDto> comments = new ArrayList<>();
 
     @Builder.Default
-    private List<CommentDto> likedComments = new ArrayList<>();
+    private List<CommentDto> commentLikes = new ArrayList<>();
 
     @Builder.Default
-    private List<ArticleViewDto> recentViewedNews = new ArrayList<>();
+    private List<ArticleViewDto> articleViews = new ArrayList<>();
 }

--- a/src/main/java/com/sprint/monew/domain/activity/UserActivityDocument.java
+++ b/src/main/java/com/sprint/monew/domain/activity/UserActivityDocument.java
@@ -1,0 +1,46 @@
+package com.sprint.monew.domain.activity;
+
+import com.sprint.monew.domain.article.dto.ArticleViewDto;
+import com.sprint.monew.domain.comment.dto.CommentDto;
+import com.sprint.monew.domain.interest.dto.SubscriptionDto;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Document(collection = "user_activities")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserActivityDocument {
+    @Id
+    private UUID id;
+
+    private String email;
+
+    private String nickname;
+
+    private Instant createdAt;
+
+    @Builder.Default
+    private List<SubscriptionDto> subscriptions = new ArrayList<>();
+
+    @Builder.Default
+    private List<CommentDto> recentComments = new ArrayList<>();
+
+    @Builder.Default
+    private List<CommentDto> likedComments = new ArrayList<>();
+
+    @Builder.Default
+    private List<ArticleViewDto> recentViewedNews = new ArrayList<>();
+}

--- a/src/main/java/com/sprint/monew/domain/activity/UserActivityDto.java
+++ b/src/main/java/com/sprint/monew/domain/activity/UserActivityDto.java
@@ -14,9 +14,9 @@ public record UserActivityDto(
         String nickname,
         Instant createdAt,
         List<SubscriptionDto> subscriptions,
-        List<CommentDto> recentComments,
-        List<CommentDto> likedComments,
-        List<ArticleViewDto> recentViewedNews
+        List<CommentDto> comments,
+        List<CommentDto> commentLikes,
+        List<ArticleViewDto> articleViews
 ) {
     public static UserActivityDto fromDocument(UserActivityDocument document) {
         return new UserActivityDto(
@@ -25,9 +25,9 @@ public record UserActivityDto(
                 document.getNickname(),
                 document.getCreatedAt(),
                 document.getSubscriptions(),
-                document.getRecentComments(),
-                document.getLikedComments(),
-                document.getRecentViewedNews()
+                document.getComments(),
+                document.getCommentLikes(),
+                document.getArticleViews()
         );
     }
 
@@ -38,9 +38,9 @@ public record UserActivityDto(
                 .nickname(dto.nickname())
                 .createdAt(dto.createdAt())
                 .subscriptions(dto.subscriptions())
-                .recentComments(dto.recentComments())
-                .likedComments(dto.likedComments())
-                .recentViewedNews(dto.recentViewedNews())
+                .comments(dto.comments())
+                .commentLikes(dto.commentLikes())
+                .articleViews(dto.articleViews())
                 .build();
     }
 }

--- a/src/main/java/com/sprint/monew/domain/activity/UserActivityDto.java
+++ b/src/main/java/com/sprint/monew/domain/activity/UserActivityDto.java
@@ -2,14 +2,18 @@ package com.sprint.monew.domain.activity;
 
 import com.sprint.monew.domain.article.dto.ArticleViewDto;
 import com.sprint.monew.domain.comment.dto.CommentDto;
+import com.sprint.monew.domain.interest.dto.SubscriptionDto;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
 public record UserActivityDto(
-        UUID userId,
-        String username,
-        List<String> subscribedInterests,
+        UUID id,
+        String email,
+        String nickname,
+        Instant createdAt,
+        List<SubscriptionDto> subscriptions,
         List<CommentDto> recentComments,
         List<CommentDto> likedComments,
         List<ArticleViewDto> recentViewedNews

--- a/src/main/java/com/sprint/monew/domain/activity/UserActivityDto.java
+++ b/src/main/java/com/sprint/monew/domain/activity/UserActivityDto.java
@@ -17,4 +17,30 @@ public record UserActivityDto(
         List<CommentDto> recentComments,
         List<CommentDto> likedComments,
         List<ArticleViewDto> recentViewedNews
-) {}
+) {
+    public static UserActivityDto fromDocument(UserActivityDocument document) {
+        return new UserActivityDto(
+                document.getId(),
+                document.getEmail(),
+                document.getNickname(),
+                document.getCreatedAt(),
+                document.getSubscriptions(),
+                document.getRecentComments(),
+                document.getLikedComments(),
+                document.getRecentViewedNews()
+        );
+    }
+
+    public static UserActivityDocument toDocument(UserActivityDto dto) {
+        return UserActivityDocument.builder()
+                .id(dto.id())
+                .email(dto.email())
+                .nickname(dto.nickname())
+                .createdAt(dto.createdAt())
+                .subscriptions(dto.subscriptions())
+                .recentComments(dto.recentComments())
+                .likedComments(dto.likedComments())
+                .recentViewedNews(dto.recentViewedNews())
+                .build();
+    }
+}

--- a/src/main/java/com/sprint/monew/domain/activity/UserActivityMongoRepository.java
+++ b/src/main/java/com/sprint/monew/domain/activity/UserActivityMongoRepository.java
@@ -1,0 +1,10 @@
+package com.sprint.monew.domain.activity;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface UserActivityMongoRepository extends MongoRepository<UserActivityDocument, UUID> {
+}

--- a/src/main/java/com/sprint/monew/domain/activity/UserActivityQueryRepository.java
+++ b/src/main/java/com/sprint/monew/domain/activity/UserActivityQueryRepository.java
@@ -1,6 +1,8 @@
 package com.sprint.monew.domain.activity;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sprint.monew.domain.article.QArticle;
 import com.sprint.monew.domain.article.articleview.QArticleView;
@@ -31,7 +33,7 @@ public class UserActivityQueryRepository {
         QUserInterest userInterest = QUserInterest.userInterest;
         QInterest interest = QInterest.interest;
         QComment comment = QComment.comment;
-        QLike like = QLike.like;
+        QLike likeSub = new QLike("likeSub");
         QArticle article = QArticle.article;
         QArticleView articleView = QArticleView.articleView;
 
@@ -51,43 +53,79 @@ public class UserActivityQueryRepository {
                         interest.id,
                         interest.name,
                         interest.keywords,
-                        interest.id,
-                        interest.createdAt))
+                        JPAExpressions
+                                .select(userInterest.count())
+                                .from(userInterest)
+                                .where(userInterest.interest.id.eq(interest.id)),
+                        interest.createdAt
+                ))
                 .from(userInterest)
                 .join(userInterest.interest, interest)
                 .where(userInterest.user.id.eq(userId))
                 .fetch();
 
         // 3. 작성한 댓글
+        // [class java.util.UUID, class java.util.UUID, class java.util.UUID, class java.lang.String, class java.lang.String, class java.lang.Integer, class java.lang.Boolean, class java.time.Instant]] with root cause
         List<CommentDto> comments = queryFactory
                 .select(Projections.constructor(CommentDto.class,
                         comment.id,
+                        comment.article.id,
+                        comment.user.id,
+                        comment.user.nickname,
                         comment.content,
-                        comment.createdAt))
+                        comment.likes.size(),
+                        JPAExpressions.selectOne()
+                                .from(likeSub)
+                                .where(likeSub.comment.id.eq(comment.id)
+                                        .and(likeSub.user.id.eq(userId)))
+                                .exists(),
+                        comment.createdAt
+                ))
                 .from(comment)
                 .where(comment.user.id.eq(userId))
                 .orderBy(comment.createdAt.desc())
                 .limit(10)
                 .fetch();
-
         // 4. 좋아요한 댓글
         List<CommentDto> likedComments = queryFactory
                 .select(Projections.constructor(CommentDto.class,
-                        like.comment.id,
-                        like.comment.content,
-                        like.comment.createdAt))
-                .from(like)
-                .where(like.user.id.eq(userId))
-                .orderBy(like.user.id.desc())
+                        comment.id,
+                        comment.article.id,
+                        comment.user.id,
+                        comment.user.nickname,
+                        comment.content,
+                        comment.likes.size(),
+                        JPAExpressions.selectOne()
+                                .from(likeSub)
+                                .where(likeSub.comment.id.eq(comment.id)
+                                        .and(likeSub.user.id.eq(userId)))
+                                .exists(),
+                        comment.createdAt
+                ))
+                .from(comment)
+                .where(comment.user.id.eq(userId))
+                .orderBy(comment.createdAt.desc())
                 .limit(10)
                 .fetch();
-
         // 5. 본 기사 기록
         List<ArticleViewDto> viewedArticles = queryFactory
                 .select(Projections.constructor(ArticleViewDto.class,
+                        articleView.user.id,
+                        articleView.user.id,
+                        articleView.createdAt,
                         article.id,
+                        article.source.stringValue(),
+                        article.sourceUrl,
                         article.title,
-                        articleView.createdAt))
+                        article.publishDate,
+                        article.summary,
+                        JPAExpressions.select(comment.count())
+                                .from(comment)
+                                .where(comment.article.id.eq(article.id)),
+                        JPAExpressions.select(articleView.count())
+                                .from(articleView)
+                                .where(articleView.article.id.eq(article.id))
+                ))
                 .from(articleView)
                 .join(articleView.article, article)
                 .where(articleView.user.id.eq(userId))

--- a/src/main/java/com/sprint/monew/domain/activity/UserActivityQueryRepository.java
+++ b/src/main/java/com/sprint/monew/domain/activity/UserActivityQueryRepository.java
@@ -3,11 +3,12 @@ package com.sprint.monew.domain.activity;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sprint.monew.domain.article.QArticle;
-import com.sprint.monew.domain.article.QArticleView;
+import com.sprint.monew.domain.article.articleview.QArticleView;
 import com.sprint.monew.domain.article.dto.ArticleViewDto;
 import com.sprint.monew.domain.comment.QComment;
 import com.sprint.monew.domain.comment.dto.CommentDto;
 import com.sprint.monew.domain.interest.QInterest;
+import com.sprint.monew.domain.interest.dto.SubscriptionDto;
 import com.sprint.monew.domain.interest.userinterest.QUserInterest;
 import com.sprint.monew.domain.like.QLike;
 import com.sprint.monew.domain.user.QUser;
@@ -34,7 +35,7 @@ public class UserActivityQueryRepository {
         QArticle article = QArticle.article;
         QArticleView articleView = QArticleView.articleView;
 
-        // 1. 사용자f
+        // 1. 사용자
         User fetchedUser = queryFactory.selectFrom(user)
                 .where(user.id.eq(userId))
                 .fetchOne();
@@ -43,9 +44,15 @@ public class UserActivityQueryRepository {
             throw new EntityNotFoundException("사용자 없음");
         }
 
-        // 2. 관심사 이름
-        List<String> interestNames = queryFactory
-                .select(interest.name)
+        // 2. 관심사
+        List<SubscriptionDto> subscriptions = queryFactory
+                .select(Projections.constructor(SubscriptionDto.class,
+                        interest.id,
+                        interest.id,
+                        interest.name,
+                        interest.keywords,
+                        interest.id,
+                        interest.createdAt))
                 .from(userInterest)
                 .join(userInterest.interest, interest)
                 .where(userInterest.user.id.eq(userId))
@@ -80,18 +87,20 @@ public class UserActivityQueryRepository {
                 .select(Projections.constructor(ArticleViewDto.class,
                         article.id,
                         article.title,
-                        articleView.viewedAt))
+                        articleView.createdAt))
                 .from(articleView)
                 .join(articleView.article, article)
                 .where(articleView.user.id.eq(userId))
-                .orderBy(articleView.viewedAt.desc())
+                .orderBy(articleView.createdAt.desc())
                 .limit(10)
                 .fetch();
 
         return new UserActivityDto(
                 userId,
+                fetchedUser.getEmail(),
                 fetchedUser.getNickname(),
-                interestNames,
+                fetchedUser.getCreatedAt(),
+                subscriptions,
                 comments,
                 likedComments,
                 viewedArticles

--- a/src/main/java/com/sprint/monew/domain/activity/UserActivityQueryRepository.java
+++ b/src/main/java/com/sprint/monew/domain/activity/UserActivityQueryRepository.java
@@ -65,7 +65,6 @@ public class UserActivityQueryRepository {
                 .fetch();
 
         // 3. 작성한 댓글
-        // [class java.util.UUID, class java.util.UUID, class java.util.UUID, class java.lang.String, class java.lang.String, class java.lang.Integer, class java.lang.Boolean, class java.time.Instant]] with root cause
         List<CommentDto> comments = queryFactory
                 .select(Projections.constructor(CommentDto.class,
                         comment.id,
@@ -86,27 +85,25 @@ public class UserActivityQueryRepository {
                 .orderBy(comment.createdAt.desc())
                 .limit(10)
                 .fetch();
+
         // 4. 좋아요한 댓글
         List<CommentDto> likedComments = queryFactory
                 .select(Projections.constructor(CommentDto.class,
-                        comment.id,
-                        comment.article.id,
-                        comment.user.id,
-                        comment.user.nickname,
-                        comment.content,
-                        comment.likes.size(),
-                        JPAExpressions.selectOne()
-                                .from(likeSub)
-                                .where(likeSub.comment.id.eq(comment.id)
-                                        .and(likeSub.user.id.eq(userId)))
-                                .exists(),
-                        comment.createdAt
+                        likeSub.comment.id,
+                        likeSub.comment.article.id,
+                        likeSub.comment.user.id,
+                        likeSub.comment.user.nickname,
+                        likeSub.comment.content,
+                        likeSub.comment.likes.size(), // 좋아요 수
+                        Expressions.constant(true), // likedByMe는 true 고정
+                        likeSub.comment.createdAt
                 ))
-                .from(comment)
-                .where(comment.user.id.eq(userId))
-                .orderBy(comment.createdAt.desc())
+                .from(likeSub)
+                .where(likeSub.user.id.eq(userId))
+                .orderBy(likeSub.comment.createdAt.desc())
                 .limit(10)
                 .fetch();
+
         // 5. 본 기사 기록
         List<ArticleViewDto> viewedArticles = queryFactory
                 .select(Projections.constructor(ArticleViewDto.class,

--- a/src/main/java/com/sprint/monew/domain/activity/UserActivityService.java
+++ b/src/main/java/com/sprint/monew/domain/activity/UserActivityService.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 public class UserActivityService {
 
     private final UserActivityQueryRepository userActivityQueryRepository;
+    private final UserActivityMongoRepository userActivityMongoRepository;
 
     public UserActivityDto getUserActivity(UUID userId) {
         return userActivityQueryRepository.findUserActivity(userId);

--- a/src/main/java/com/sprint/monew/domain/activity/UserActivityService.java
+++ b/src/main/java/com/sprint/monew/domain/activity/UserActivityService.java
@@ -3,6 +3,7 @@ package com.sprint.monew.domain.activity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.util.UUID;
 
 @Service
@@ -14,5 +15,22 @@ public class UserActivityService {
 
     public UserActivityDto getUserActivity(UUID userId) {
         return userActivityQueryRepository.findUserActivity(userId);
+    }
+
+    public UserActivityDto getUserActivityFromMongo(UUID userId) {
+        UserActivityDocument document = userActivityMongoRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found in MongoDB: " + userId));
+
+        return UserActivityDto.fromDocument(document);
+    }
+
+    public UserActivityDto saveUserActivityToMongo(UUID userId) {
+        UserActivityDto dto = userActivityQueryRepository.findUserActivity(userId);
+
+        UserActivityDocument document = UserActivityDto.toDocument(dto);
+
+        userActivityMongoRepository.save(document);
+
+        return dto;
     }
 }

--- a/src/main/java/com/sprint/monew/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/sprint/monew/domain/comment/dto/CommentDto.java
@@ -13,7 +13,7 @@ public record CommentDto(
         UUID userId,
         String userNickname,
         String content,
-        long likeCount,
+        int likeCount,
         boolean likedByMe,
         Instant createdAt
 ) {

--- a/src/main/java/com/sprint/monew/domain/interest/dto/SubscriptionDto.java
+++ b/src/main/java/com/sprint/monew/domain/interest/dto/SubscriptionDto.java
@@ -10,7 +10,7 @@ public record SubscriptionDto(
     UUID interestId,
     String interestName,
     List<String> interestKeywords,
-    int interestSubscriberCount,
+    long interestSubscriberCount,
     Instant createdAt
 ) {
 

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -13,6 +13,10 @@ spring:
   batch:
       job:
         initialize-schema: never
+  data:
+    mongodb:
+      uri: ${MONGODB_URI}
+      database: ${MONGODB_DATABASE}
 
 logging:
   level:


### PR DESCRIPTION
## 🛰️ Issue Number
- #74 
## 🪐 작업 내용
- MongoDB 의존성 추가
- UserActivityDto 수정
- `getUserActivityFromMongo`, `getUserActivity`, `saveUserActivityToMongo` api 추가
- MongoDB atlas (cloud free tier) 추가
## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
