### PR TITLE
fix/test:  문자열 유사도 검사 기능 개선, 관심사 통합 테스트 코드 구현

### DIFF
--- a/src/main/java/com/sprint/monew/common/util/SimilarityCalculator.java
+++ b/src/main/java/com/sprint/monew/common/util/SimilarityCalculator.java
@@ -1,5 +1,9 @@
 package com.sprint.monew.common.util;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 public class SimilarityCalculator {
 
   //두 문자열 간 유사도 검사
@@ -12,19 +16,43 @@ public class SimilarityCalculator {
       return 0.0;
     }
 
-    int distance = levenshteinDistance(str1, str2);
+    // 대소문자 구분 없애기
+    str1 = str1.toLowerCase();
+    str2 = str2.toLowerCase();
 
-    // 최대 가능한 거리 (더 긴 문자열의 길이)
-    int maxLength = Math.max(str1.length(), str2.length());
+    // 특수문자와 공백을 기준으로 단어 분리
+    String[] words1 = str1.split("[\\s\\p{Punct}및]+");
+    String[] words2 = str2.split("[\\s\\p{Punct}및]+");
 
-    //유사도 계산
-    return 1.0 - ((double) distance / maxLength);
+    // 빈 문자열 제거
+    words1 = removeEmptyStrings(words1);
+    words2 = removeEmptyStrings(words2);
+
+    // 분리된 단어가 있는지 확인
+    boolean isMultipleWords1 = words1.length > 1;
+    boolean isMultipleWords2 = words2.length > 1;
+
+    // 둘 중 하나라도 여러 단어로 분리된 경우 -> 자카드 유사도
+    if (isMultipleWords1 || isMultipleWords2) {
+      return calculateJaccardSimilarity(words1, words2);
+    }
+    // 둘 다 단일 단어인 경우 -> 레벤슈타인 거리
+    else {
+      return levenshteinDistance(str1, str2);
+    }
+  }
+
+  // 빈 문자열 제거하는 메서드
+  private static String[] removeEmptyStrings(String[] arr) {
+    return Arrays.stream(arr)
+        .filter(s -> !s.isEmpty())
+        .toArray(String[]::new);
   }
 
   /**
    * 레벤슈타인 거리를 계산 한 문자열에서 다른 문자열로 변환하는 데 필요한 최소 편집 연산(삽입, 삭제, 대체)의 수.
    */
-  private static int levenshteinDistance(String str1, String str2) {
+  private static double levenshteinDistance(String str1, String str2) {
     int[][] dp = new int[str1.length() + 1][str2.length() + 1];
 
     for (int i = 0; i <= str1.length(); i++) {
@@ -44,6 +72,29 @@ public class SimilarityCalculator {
         );
       }
     }
-    return dp[str1.length()][str2.length()];
+
+    // 최대 가능한 거리 (더 긴 문자열의 길이)
+    int maxLength = Math.max(str1.length(), str2.length());
+
+    return 1.0 - ((double) dp[str1.length()][str2.length()] / maxLength);
+  }
+
+
+  // 자카드 유사도 계산
+  private static double calculateJaccardSimilarity(String[] words1, String[] words2) {
+    // 중복 제거를 위해 Set으로 변환
+    Set<String> set1 = new HashSet<>(Arrays.asList(words1));
+    Set<String> set2 = new HashSet<>(Arrays.asList(words2));
+
+    // 교집합을 계산
+    Set<String> intersection = new HashSet<>(set1);
+    intersection.retainAll(set2);
+
+    // 합집합을 계산
+    Set<String> union = new HashSet<>(set1);
+    union.addAll(set2);
+
+    // 자카드 유사도 = 교집합 크기 / 합집합 크기
+    return union.isEmpty() ? 1.0 : (double) intersection.size() / union.size();
   }
 }

--- a/src/main/java/com/sprint/monew/domain/interest/InterestController.java
+++ b/src/main/java/com/sprint/monew/domain/interest/InterestController.java
@@ -72,6 +72,6 @@ public class InterestController {
       @RequestBody InterestUpdateRequest interestUpdateRequest,
       @RequestHeader(name = "Monew-Request-User-ID", required = false) UUID userId) {
     return ResponseEntity.ok(
-        interestService.updateInterest(interestId, userId, interestUpdateRequest));
+        interestService.updateInterest(userId, interestId, interestUpdateRequest));
   }
 }

--- a/src/main/java/com/sprint/monew/domain/interest/InterestRepository.java
+++ b/src/main/java/com/sprint/monew/domain/interest/InterestRepository.java
@@ -19,7 +19,7 @@ public interface InterestRepository extends JpaRepository<Interest, UUID>,
           "WHERE LOWER(k) LIKE LOWER(CONCAT('%', :keyword, '%')))) " +
           "AND (:cursorId IS NULL OR "
           + " (cast(:after as timestamptz) IS NOT NULL AND i.created_at > :after) OR"
-          + " (cast(:after as timestamptz) IS NOT NULL AND i.created_at > :after AND i.id >: cursorId)) "
+          + " (cast(:after as timestamptz) IS NOT NULL AND i.created_at > :after AND i.id > :cursorId)) "
           + "ORDER BY i.name ASC, i.id ASC "
           + "LIMIT :limit",
       nativeQuery = true)
@@ -34,7 +34,7 @@ public interface InterestRepository extends JpaRepository<Interest, UUID>,
           "WHERE LOWER(k) LIKE LOWER(CONCAT('%', :keyword, '%')))) " +
           "AND (:cursorId IS NULL OR "
           + " (cast(:after as timestamptz) IS NOT NULL AND i.created_at < :after) OR"
-          + " (cast(:after as timestamptz) IS NOT NULL AND i.created_at < :after AND i.id <: cursorId)) "
+          + " (cast(:after as timestamptz) IS NOT NULL AND i.created_at < :after AND i.id < :cursorId)) "
           + "ORDER BY i.name DESC, i.id DESC "
           + "LIMIT :limit",
       nativeQuery = true)

--- a/src/main/java/com/sprint/monew/domain/interest/InterestWithSubscriberCount.java
+++ b/src/main/java/com/sprint/monew/domain/interest/InterestWithSubscriberCount.java
@@ -1,7 +1,6 @@
 package com.sprint.monew.domain.interest;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 
 //QueryDsl 적용 시 class 로 바꿔야 하는지
@@ -11,7 +10,7 @@ public interface InterestWithSubscriberCount {
 
   String getName();
 
-  List<String> getKeywords();
+  String getKeywords();
 
   Instant getCreatedAt();
 

--- a/src/main/java/com/sprint/monew/domain/interest/dto/InterestDto.java
+++ b/src/main/java/com/sprint/monew/domain/interest/dto/InterestDto.java
@@ -2,6 +2,7 @@ package com.sprint.monew.domain.interest.dto;
 
 import com.sprint.monew.domain.interest.Interest;
 import com.sprint.monew.domain.interest.InterestWithSubscriberCount;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -23,12 +24,45 @@ public record InterestDto(
     );
   }
 
+  //임시 파싱 메서드
+  //todo - queryDsl 적용 시 삭제 또는 리팩토링
   public static InterestDto from(InterestWithSubscriberCount interestWithSubscriberCount,
       boolean subscribedByMe) {
+
+    // keywords 문자열 파싱한 결과를 담을 배열
+    List<String> parsedKeywords = new ArrayList<>();
+    String rawKeywords = interestWithSubscriberCount.getKeywords();
+
+    // 맨 앞의 '[' 와 맨 뒤의 ']' 제거
+    if (rawKeywords != null && !rawKeywords.isEmpty()) {
+      String trimmed = rawKeywords.trim();
+      if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+        trimmed = trimmed.substring(1, trimmed.length() - 1);
+      }
+
+      // 쉼표로 키워드들 분리
+      String[] keywordArray = trimmed.split(",");
+
+      for (String keyword : keywordArray) {
+        // 각 키워드 정리, 따옴표 및 공백 제거
+        keyword = keyword.trim();
+        if (keyword.startsWith("\"") && keyword.endsWith("\"")) {
+          keyword = keyword.substring(1, keyword.length() - 1);
+        }
+        // 특수문자 처리된 따옴표 처리 (\" -> ")
+        keyword = keyword.replace("\\\"", "\"");
+
+        //처리한 문자열이 비어있지 않다면 키워드!
+        if (!keyword.isEmpty()) {
+          parsedKeywords.add(keyword);
+        }
+      }
+    }
+
     return new InterestDto(
         interestWithSubscriberCount.getId(),
         interestWithSubscriberCount.getName(),
-        interestWithSubscriberCount.getKeywords(),
+        parsedKeywords,
         interestWithSubscriberCount.getSubscriberCount(),
         subscribedByMe
     );

--- a/src/test/java/com/sprint/monew/common/util/SimilarityCalculatorTest.java
+++ b/src/test/java/com/sprint/monew/common/util/SimilarityCalculatorTest.java
@@ -1,0 +1,93 @@
+package com.sprint.monew.common.util;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("문자열 유사도 검사 클래스 테스트")
+class SimilarityCalculatorTest {
+
+  @Test
+  @DisplayName("동일한 문자열")
+  void calculate() {
+    String str1 = "음악";
+    String str2 = "음악";
+
+    double v = SimilarityCalculator.calculateSimilarity(str1, str2);
+    assertTrue(v == 1);
+    System.out.println(v);
+  }
+
+  @Test
+  @DisplayName("5글자중 한글자만 다른 문자열(80% 유사)")
+  void calculate2() {
+    String str1 = "프로그래밍";
+    String str2 = "프로그래";
+
+    double v = SimilarityCalculator.calculateSimilarity(str1, str2);
+    assertTrue(v >= 0.8);
+    System.out.println(v);
+  }
+
+  @Test
+  @DisplayName("4글자중 한글자만 다른 문자열(75% 유사)")
+  void calculate3() {
+    String str1 = "음악예술";
+    String str2 = "음악애술";
+
+    double v = SimilarityCalculator.calculateSimilarity(str1, str2);
+    assertTrue(v < 0.8);
+    System.out.println(v);
+  }
+
+  @Test
+  @DisplayName("모두 일치하지 않는 문자열")
+  void calculateDistance() {
+
+    String str1 = "음악";
+    String str2 = "예술";
+
+    double v = SimilarityCalculator.calculateSimilarity(str1, str2);
+    assertTrue(v < 1);
+    System.out.println(v);
+  }
+
+
+  @Test
+  @DisplayName("50%만 일치하는 문자열")
+  void calculateDifference() {
+
+    String str1 = "음악/예술";
+    String str2 = "예술";
+
+    double v = SimilarityCalculator.calculateSimilarity(str1, str2);
+    assertTrue(v == 0.5);
+    System.out.println(v);
+  }
+
+
+  @Test
+  @DisplayName("\"및\"으로 구분되어있고 단어 순서만 다른 동일한 관심사 ")
+  void calculateDifference2() {
+
+    String str1 = "음악 및 예술";
+    String str2 = "예술 및 음악";
+
+    double v = SimilarityCalculator.calculateSimilarity(str1, str2);
+    assertTrue(v == 1);
+    System.out.println(v);
+  }
+
+  @Test
+  @DisplayName(" \"and\"로 구분되어있고, 대소문자와 단어 순서만 다른 동일한 관심사")
+  void calculateDifference4() {
+
+    String str1 = "Art And Music";
+    String str2 = "music and art";
+
+    double v = SimilarityCalculator.calculateSimilarity(str1, str2);
+    assertTrue(v == 1);
+    System.out.println(v);
+  }
+}

--- a/src/test/java/com/sprint/monew/domain/interest/InterestServiceTest.java
+++ b/src/test/java/com/sprint/monew/domain/interest/InterestServiceTest.java
@@ -76,7 +76,7 @@ class InterestServiceTest {
     interests.add(programming);
 
     // 두 번째 테스트 데이터 - 음악 관심사
-    Interest music = new Interest("음악", Arrays.asList("클래식", "재즈", "힙합"));
+    Interest music = new Interest("음악/예술", Arrays.asList("클래식", "재즈", "힙합"));
     setPrivateField(music, "id", UUID.fromString("b2c3d4e5-f6a7-5b6c-9d0e-1f2a3b4c5d6"));
     interests.add(music);
 
@@ -148,7 +148,7 @@ class InterestServiceTest {
     void createInterestFailure() {
       //given
       InterestCreateRequest request = new InterestCreateRequest(
-          "프로그래밍1", List.of("개발자", "기술", "개발", "AI")
+          "예술/음악", List.of("클래식", "재즈", "힙합")
       );
       Interest mockInterest = new Interest(request.name(), request.keywords());
 

--- a/src/test/java/com/sprint/monew/integration/InterestIntegrationTest.java
+++ b/src/test/java/com/sprint/monew/integration/InterestIntegrationTest.java
@@ -1,0 +1,518 @@
+package com.sprint.monew.integration;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sprint.monew.PostgresContainer;
+import com.sprint.monew.domain.interest.dto.InterestCreateRequest;
+import com.sprint.monew.domain.interest.dto.InterestUpdateRequest;
+import com.sprint.monew.domain.user.UserRegisterRequest;
+import java.util.Arrays;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("관심사 API 통합 테스트")
+public class InterestIntegrationTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  static final PostgresContainer postgresContainer = PostgresContainer.getInstance();
+
+  static {
+    postgresContainer.start();
+  }
+
+  @DynamicPropertySource
+  static void overrideDataSourceProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgresContainer::getJdbcUrl);
+    registry.add("spring.datasource.username", postgresContainer::getUsername);
+    registry.add("spring.datasource.password", postgresContainer::getPassword);
+  }
+
+  @Nested
+  @DisplayName("관심사 등록")
+  class interestRegister {
+
+    @Test
+    @DisplayName("성공")
+    void success() throws Exception {
+      //given
+      InterestCreateRequest request = new InterestCreateRequest(
+          "음악/예술", Arrays.asList("클래식", "재즈", "힙합", "현대미술")
+      );
+
+      String requestBody = objectMapper.writeValueAsString(request);
+
+      //when & then
+      mockMvc.perform(post("/api/interests")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(requestBody))
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.id", notNullValue()))
+          .andExpect(jsonPath("$.name", is("음악/예술")))
+          .andExpect(jsonPath("$.keywords", containsInAnyOrder("클래식", "재즈", "힙합", "현대미술")))
+          .andExpect(jsonPath("$.subscriberCount", notNullValue()))
+          .andExpect(jsonPath("$.subscribedByMe", notNullValue()));
+    }
+
+    @Test
+    @DisplayName("실패: 유사한 이름 관심사 존재")
+    void failureSinceSimilarInterestExists() throws Exception {
+      InterestCreateRequest firstRequest = new InterestCreateRequest(
+          "음악/예술", Arrays.asList("클래식", "재즈", "힙합", "현대미술")
+      );
+      String firstRequestBody = objectMapper.writeValueAsString(firstRequest);
+
+      //when & then
+      mockMvc.perform(post("/api/interests")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(firstRequestBody))
+          .andExpect(status().isCreated());
+
+      InterestCreateRequest secondRequest = new InterestCreateRequest(
+          "예술/음악", Arrays.asList("클래식", "재즈", "힙합", "현대미술")
+      );
+
+      String secondRequestBody = objectMapper.writeValueAsString(secondRequest);
+
+      mockMvc.perform(post("/api/interests")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(secondRequestBody))
+          .andExpect(status().isConflict());
+    }
+  }
+
+  @Nested
+  @DisplayName("관심사 구독")
+  class interestSubscribe {
+
+    @Test
+    @DisplayName("성공")
+    void success() throws Exception {
+      //given
+      // 1. 사용자 등록
+      UserRegisterRequest registerRequest = new UserRegisterRequest(
+          "test@test.com",
+          "testUser",
+          "password1234"
+      );
+
+      MvcResult creatUserResult = mockMvc.perform(post("/api/users")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(registerRequest)))
+          .andExpect(status().isCreated())
+          .andReturn();
+
+      // 2. 생성된 사용자 ID 추출
+      String responseJson = creatUserResult.getResponse().getContentAsString();
+      String userId = objectMapper.readTree(responseJson).get("id").asText();
+
+      // 3. 관심사 등록
+      InterestCreateRequest createRequest = new InterestCreateRequest(
+          "음악/예술", Arrays.asList("클래식", "재즈", "힙합", "현대미술")
+      );
+
+      String requestBody = objectMapper.writeValueAsString(createRequest);
+
+      MvcResult createResult = mockMvc.perform(post("/api/interests")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(requestBody))
+          .andExpect(status().isCreated())
+          .andReturn();
+
+      // 4. 생성된 관심사 ID 추출
+      String responseInterestJson = createResult.getResponse().getContentAsString();
+      String interestId = objectMapper.readTree(responseInterestJson).get("id").asText();
+
+      //when & then
+      mockMvc.perform(post("/api/interests/" + interestId + "/subscriptions")
+              .contentType(MediaType.APPLICATION_JSON)
+              .header("Monew-Request-User-ID", userId))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.id", notNullValue()))
+          .andExpect(jsonPath("$.interestId", is(interestId)))
+          .andExpect(jsonPath("$.interestName", is("음악/예술")))
+          .andExpect(jsonPath("$.interestKeywords", containsInAnyOrder("클래식", "재즈", "힙합", "현대미술")))
+          .andExpect(jsonPath("$.createdAt", notNullValue()))
+          .andExpect(jsonPath("$.interestSubscriberCount", notNullValue()));
+    }
+
+    @Test
+    @DisplayName("실패: 해당 ID의 사용자가 존재하지 않음")
+    void failureSinceUserId() throws Exception {
+      //given
+      UUID randomUserUUID = UUID.randomUUID();
+
+      InterestCreateRequest createRequest = new InterestCreateRequest(
+          "음악/예술", Arrays.asList("클래식", "재즈", "힙합", "현대미술")
+      );
+
+      String requestBody = objectMapper.writeValueAsString(createRequest);
+
+      MvcResult createResult = mockMvc.perform(post("/api/interests")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(requestBody))
+          .andExpect(status().isCreated())
+          .andReturn();
+
+      // 4. 생성된 관심사 ID 추출
+      String responseInterestJson = createResult.getResponse().getContentAsString();
+      String interestId = objectMapper.readTree(responseInterestJson).get("id").asText();
+
+      //when & then
+      mockMvc.perform(post("/api/interests/" + interestId + "/subscriptions")
+              .contentType(MediaType.APPLICATION_JSON)
+              .header("Monew-Request-User-ID", randomUserUUID))
+          .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("실패: 해당 ID의 관심사가 존재하지 않음")
+    void failureSinceInterestId() throws Exception {
+      //given
+      // 1. 사용자 등록
+      UserRegisterRequest registerRequest = new UserRegisterRequest(
+          "test@test.com",
+          "testUser",
+          "password1234"
+      );
+
+      MvcResult creatUserResult = mockMvc.perform(post("/api/users")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(registerRequest)))
+          .andExpect(status().isCreated())
+          .andReturn();
+
+      // 2. 생성된 사용자 ID 추출
+      String responseJson = creatUserResult.getResponse().getContentAsString();
+      String userId = objectMapper.readTree(responseJson).get("id").asText();
+
+      UUID randomInterestUUID = UUID.randomUUID();
+
+      //when & then
+      mockMvc.perform(post("/api/interests/" + randomInterestUUID + "/subscriptions")
+              .contentType(MediaType.APPLICATION_JSON)
+              .header("Monew-Request-User-ID", userId))
+          .andExpect(status().isNotFound());
+    }
+  }
+
+  @Nested
+  @DisplayName("관심사 구독 취소")
+  class interestUnsubscribe {
+
+    @Test
+    @DisplayName("성공")
+    void success() throws Exception {
+      //given
+      // 1. 사용자 등록
+      UserRegisterRequest registerRequest = new UserRegisterRequest(
+          "test@test.com",
+          "testUser",
+          "password1234"
+      );
+
+      MvcResult creatUserResult = mockMvc.perform(post("/api/users")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(registerRequest)))
+          .andExpect(status().isCreated())
+          .andReturn();
+
+      // 2. 생성된 사용자 ID 추출
+      String responseJson = creatUserResult.getResponse().getContentAsString();
+      String userId = objectMapper.readTree(responseJson).get("id").asText();
+
+      // 3. 관심사 등록
+      InterestCreateRequest createRequest = new InterestCreateRequest(
+          "음악/예술", Arrays.asList("클래식", "재즈", "힙합", "현대미술")
+      );
+
+      String requestBody = objectMapper.writeValueAsString(createRequest);
+
+      MvcResult createResult = mockMvc.perform(post("/api/interests")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(requestBody))
+          .andExpect(status().isCreated())
+          .andReturn();
+
+      // 4. 생성된 관심사 ID 추출
+      String responseInterestJson = createResult.getResponse().getContentAsString();
+      String interestId = objectMapper.readTree(responseInterestJson).get("id").asText();
+
+      // 5. 관심사 구독
+      mockMvc.perform(post("/api/interests/" + interestId + "/subscriptions")
+              .contentType(MediaType.APPLICATION_JSON)
+              .header("Monew-Request-User-ID", userId))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.id", notNullValue()))
+          .andExpect(jsonPath("$.interestId", is(interestId)))
+          .andExpect(jsonPath("$.interestName", is("음악/예술")))
+          .andExpect(jsonPath("$.interestKeywords", containsInAnyOrder("클래식", "재즈", "힙합", "현대미술")))
+          .andExpect(jsonPath("$.createdAt", notNullValue()))
+          .andExpect(jsonPath("$.interestSubscriberCount", notNullValue()));
+
+      //when&then
+      mockMvc.perform(delete("/api/interests/" + interestId + "/subscriptions")
+              .contentType(MediaType.APPLICATION_JSON)
+              .header("Monew-Request-User-ID", userId))
+          .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("실패: 해당 ID의 사용자가 존재하지 않음")
+    void failureSinceUserId() throws Exception {
+      //given
+      // 1. 사용자 등록
+      UserRegisterRequest registerRequest = new UserRegisterRequest(
+          "test@test.com",
+          "testUser",
+          "password1234"
+      );
+
+      MvcResult creatUserResult = mockMvc.perform(post("/api/users")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(registerRequest)))
+          .andExpect(status().isCreated())
+          .andReturn();
+
+      // 2. 생성된 사용자 ID 추출
+      String responseJson = creatUserResult.getResponse().getContentAsString();
+      String userId = objectMapper.readTree(responseJson).get("id").asText();
+
+      // 3. 관심사 등록
+      InterestCreateRequest createRequest = new InterestCreateRequest(
+          "음악/예술", Arrays.asList("클래식", "재즈", "힙합", "현대미술")
+      );
+
+      String requestBody = objectMapper.writeValueAsString(createRequest);
+
+      MvcResult createResult = mockMvc.perform(post("/api/interests")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(requestBody))
+          .andExpect(status().isCreated())
+          .andReturn();
+
+      // 4. 생성된 관심사 ID 추출
+      String responseInterestJson = createResult.getResponse().getContentAsString();
+      String interestId = objectMapper.readTree(responseInterestJson).get("id").asText();
+
+      // 5. 관심사 구독
+      mockMvc.perform(post("/api/interests/" + interestId + "/subscriptions")
+              .contentType(MediaType.APPLICATION_JSON)
+              .header("Monew-Request-User-ID", userId))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.id", notNullValue()))
+          .andExpect(jsonPath("$.interestId", is(interestId)))
+          .andExpect(jsonPath("$.interestName", is("음악/예술")))
+          .andExpect(jsonPath("$.interestKeywords", containsInAnyOrder("클래식", "재즈", "힙합", "현대미술")))
+          .andExpect(jsonPath("$.createdAt", notNullValue()))
+          .andExpect(jsonPath("$.interestSubscriberCount", notNullValue()));
+
+      // 6. 잘못된 userID
+      UUID randomUUID = UUID.randomUUID();
+
+      //when&then
+      mockMvc.perform(delete("/api/interests/" + interestId + "/subscriptions")
+              .contentType(MediaType.APPLICATION_JSON)
+              .header("Monew-Request-User-ID", randomUUID))
+          .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("실패: 해당 ID의 관심사가 존재하지 않음")
+    void failureSinceInterestId() throws Exception {
+      //given
+      // 1. 사용자 등록
+      UserRegisterRequest registerRequest = new UserRegisterRequest(
+          "test@test.com",
+          "testUser",
+          "password1234"
+      );
+
+      MvcResult creatUserResult = mockMvc.perform(post("/api/users")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(registerRequest)))
+          .andExpect(status().isCreated())
+          .andReturn();
+
+      // 2. 생성된 사용자 ID 추출
+      String responseJson = creatUserResult.getResponse().getContentAsString();
+      String userId = objectMapper.readTree(responseJson).get("id").asText();
+
+      // 3. 관심사 등록
+      InterestCreateRequest createRequest = new InterestCreateRequest(
+          "음악/예술", Arrays.asList("클래식", "재즈", "힙합", "현대미술")
+      );
+
+      String requestBody = objectMapper.writeValueAsString(createRequest);
+
+      MvcResult createResult = mockMvc.perform(post("/api/interests")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(requestBody))
+          .andExpect(status().isCreated())
+          .andReturn();
+
+      // 4. 생성된 관심사 ID 추출
+      String responseInterestJson = createResult.getResponse().getContentAsString();
+      String interestId = objectMapper.readTree(responseInterestJson).get("id").asText();
+
+      // 5. 관심사 구독
+      mockMvc.perform(post("/api/interests/" + interestId + "/subscriptions")
+              .contentType(MediaType.APPLICATION_JSON)
+              .header("Monew-Request-User-ID", userId))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.id", notNullValue()))
+          .andExpect(jsonPath("$.interestId", is(interestId)))
+          .andExpect(jsonPath("$.interestName", is("음악/예술")))
+          .andExpect(jsonPath("$.interestKeywords", containsInAnyOrder("클래식", "재즈", "힙합", "현대미술")))
+          .andExpect(jsonPath("$.createdAt", notNullValue()))
+          .andExpect(jsonPath("$.interestSubscriberCount", notNullValue()));
+
+      // 6. 잘못된 관심사 ID
+      UUID randomUUID = UUID.randomUUID();
+
+      //when&then
+      mockMvc.perform(delete("/api/interests/" + randomUUID + "/subscriptions")
+              .contentType(MediaType.APPLICATION_JSON)
+              .header("Monew-Request-User-ID", userId))
+          .andExpect(status().isNotFound());
+    }
+
+  }
+
+
+  @Nested
+  @DisplayName("관심사 수정")
+  class interestModify {
+
+    @Test
+    @DisplayName("성공")
+    void success() throws Exception {
+      //given
+      // 1. 관심사 등록
+      InterestCreateRequest createRequest = new InterestCreateRequest(
+          "음악/예술", Arrays.asList("클래식", "재즈", "힙합", "현대미술")
+      );
+
+      String requestBody = objectMapper.writeValueAsString(createRequest);
+
+      MvcResult createResult = mockMvc.perform(post("/api/interests")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(requestBody))
+          .andExpect(status().isCreated())
+          .andReturn();
+
+      // 2. 생성된 관심사 ID 추출
+      String responseInterestJson = createResult.getResponse().getContentAsString();
+      String interestId = objectMapper.readTree(responseInterestJson).get("id").asText();
+
+      // 3. 요청값 준비
+      InterestUpdateRequest updateRequest = new InterestUpdateRequest(
+          Arrays.asList("클래식", "재즈", "힙합", "현대미술")
+      );
+      String updateRequestBody = objectMapper.writeValueAsString(updateRequest);
+
+      //when & then
+      mockMvc.perform(patch("/api/interests/" + interestId)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(updateRequestBody))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.id", notNullValue()))
+          .andExpect(jsonPath("$.name", is("음악/예술")))
+          .andExpect(jsonPath("$.keywords", containsInAnyOrder("클래식", "재즈", "힙합", "현대미술")));
+    }
+
+    @Test
+    @DisplayName("실패: 해당 ID의 관심사가 존재하지 않음")
+    void failureSinceInterestId() throws Exception {
+      UUID randomUUID = UUID.randomUUID();
+      InterestUpdateRequest updateRequest = new InterestUpdateRequest(
+          Arrays.asList("클래식", "재즈", "힙합", "현대미술")
+      );
+      String updateRequestBody = objectMapper.writeValueAsString(updateRequest);
+
+      //when & then
+      mockMvc.perform(patch("/api/interests/" + randomUUID)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(updateRequestBody))
+          .andExpect(status().isNotFound());
+    }
+  }
+
+  @Nested
+  @DisplayName("관심사 삭제")
+  class interestDelete {
+
+    @Test
+    @DisplayName("성공")
+    void success() throws Exception {
+      //given
+      // 1. 관심사 등록
+      InterestCreateRequest createRequest = new InterestCreateRequest(
+          "음악/예술", Arrays.asList("클래식", "재즈", "힙합", "현대미술")
+      );
+
+      String requestBody = objectMapper.writeValueAsString(createRequest);
+
+      MvcResult createResult = mockMvc.perform(post("/api/interests")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(requestBody))
+          .andExpect(status().isCreated())
+          .andReturn();
+
+      // 2. 생성된 관심사 ID 추출
+      String responseInterestJson = createResult.getResponse().getContentAsString();
+      String interestId = objectMapper.readTree(responseInterestJson).get("id").asText();
+
+      //when & then
+      mockMvc.perform(delete("/api/interests/" + interestId)
+              .contentType(MediaType.APPLICATION_JSON))
+          .andExpect(status().isNoContent());
+
+      mockMvc.perform(delete("/api/interests/" + interestId)
+              .contentType(MediaType.APPLICATION_JSON))
+          .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("실패: 해당 ID의 관심사가 존재하지 않음")
+    void failureSinceInterestId() throws Exception {
+      //given
+      UUID randomUUID = UUID.randomUUID();
+
+      //when & then
+      mockMvc.perform(delete("/api/interests/" + randomUUID)
+              .contentType(MediaType.APPLICATION_JSON))
+          .andExpect(status().isNotFound());
+    }
+  }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- #87 
- #102

## 🪐 작업 내용
### 1. 문자열 유사도 계산 로직 개선
- #102 에 상세히 적어두었습니다.

### 2. 문자열 유사도 계산 클래스 분리 및 테스트 코드 구현
- 기존에 관심사 클래스에 있던 로직을 따로 분리하여 `SimilarityCalculator`클래스를 만들었습니다. (요한님 피드백)
- 유사도 검사 메소드도 테스트가 필요하다고 판단하여 간단하게 테스트 코드를 구현하였습니다.

### 3. 관심사 통합 테스트 코드 구현
- 성삼님 코드 참고하여 `등록`, `수정`, `삭제`, `구독`. `구독 취소`에 대한 테스트 코드를 구현하였습니다. 
- `조회`의 경우 동적쿼리 적용 후 구현할 예정입니다.

### 4. 기타
- 관심사 정보 수정 기능 파라미터 전달 오류 수정
- 관심사 쿼리 오타로 인한 파라미터 매핑 에러 수정
- subscriberCount로 조회 시 키워드 리스트 파싱 기능 추가
  - 해당 부분은 동적 쿼리 적용 시 삭제될 가능성이 높습니다!

## 📚 Reference
### 유사도 계산
- [퇴근-후-문자열-유사성-알고리즘-적용해서-업무-개선해보기](https://velog.io/@h-go-getter/%ED%87%B4%EA%B7%BC-%ED%9B%84-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%9C%A0%EC%82%AC%EC%84%B1-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EC%A0%81%EC%9A%A9%ED%95%B4%EC%84%9C-%EC%97%85%EB%AC%B4-%EA%B0%9C%EC%84%A0%ED%95%B4%EB%B3%B4%EA%B8%B0)
- [자카드 유사도(Jaccard Similarity) 개념 이해](https://velog.io/@cjyooong/%EC%9E%90%EC%B9%B4%EB%93%9C-%EC%9C%A0%EC%82%AC%EB%8F%84Jaccard-Similarity-%EA%B0%9C%EB%85%90-%EC%9D%B4%ED%95%B4)
- claud.ai 도움

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
