### PR TITLE
fix: articles_interests 스키마 누락된 created_at 필드 추가

### DIFF
--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -78,8 +78,9 @@ CREATE TABLE "likes"
 CREATE TABLE "articles_interests"
 (
     "id"          UUID PRIMARY KEY,
-    "article_id"  UUID NOT NULL,
-    "interest_id" UUID NOT NULL,
+    "article_id"  UUID        NOT NULL,
+    "interest_id" UUID        NOT NULL,
+    "created_at"  TIMESTAMPTZ NOT NULL DEFAULT now(),
     UNIQUE (article_id, interest_id)
 );
 


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
 articles_interests 스키마 누락된 created_at 필드 추가

## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
