### PR TITLE
fix: TestInterestWithSubscriberCount getKeywords()메소드 반환값 수정

### DIFF
--- a/src/test/java/com/sprint/monew/domain/interest/TestInterestWithSubscriberCount.java
+++ b/src/test/java/com/sprint/monew/domain/interest/TestInterestWithSubscriberCount.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.UUID;
 
 class TestInterestWithSubscriberCount implements InterestWithSubscriberCount {
+
   private UUID id;
   private String name;
   private List<String> keywords;
@@ -31,8 +32,8 @@ class TestInterestWithSubscriberCount implements InterestWithSubscriberCount {
   }
 
   @Override
-  public List<String> getKeywords() {
-    return keywords;
+  public String getKeywords() {
+    return String.join(",", keywords);
   }
 
   @Override


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용

## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
