### PR TITLE
test: mongodb mvc 테스트 추가

### DIFF
--- a/src/main/java/com/sprint/monew/domain/activity/UserActivityController.java
+++ b/src/main/java/com/sprint/monew/domain/activity/UserActivityController.java
@@ -41,4 +41,13 @@ public class UserActivityController {
   ) {
     return ResponseEntity.ok(userActivityService.saveUserActivityToMongo(userId));
   }
+
+  @GetMapping("/{userId}/update")
+  public ResponseEntity<Void> updateUserActivityToMongo(
+      @PathVariable UUID userId,
+      @RequestHeader(name = "Monew-Request-User-ID", required = false) UUID headerUserId
+  ) {
+    userActivityService.updateUserActivity(userId);
+    return ResponseEntity.ok(null);
+  }
 }

--- a/src/main/java/com/sprint/monew/domain/article/articleview/ArticleView.java
+++ b/src/main/java/com/sprint/monew/domain/article/articleview/ArticleView.java
@@ -50,6 +50,7 @@ public class ArticleView {
   private ArticleView(User user, Article article) {
     this.user = user;
     this.article = article;
+    this.createdAt = Instant.now();
   }
 
   public static ArticleView create(User user, Article article) {

--- a/src/main/java/com/sprint/monew/domain/comment/Comment.java
+++ b/src/main/java/com/sprint/monew/domain/comment/Comment.java
@@ -66,6 +66,7 @@ public class Comment {
     this.article = article;
     this.content = content;
     this.deleted = false;
+    this.createdAt = Instant.now();
   }
 
   public static Comment create(User user, Article article, String content) {

--- a/src/main/java/com/sprint/monew/domain/interest/subscription/SubscriptionDto.java
+++ b/src/main/java/com/sprint/monew/domain/interest/subscription/SubscriptionDto.java
@@ -9,7 +9,7 @@ public record SubscriptionDto(
     UUID interestId,
     String interestName,
     List<String> interestKeywords,
-    int interestSubscriberCount,
+    long interestSubscriberCount,
     Instant createdAt
 ) {
 

--- a/src/test/java/com/sprint/monew/common/config/TestQuerydslConfig.java
+++ b/src/test/java/com/sprint/monew/common/config/TestQuerydslConfig.java
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
-@EnableJpaAuditing
 public class TestQuerydslConfig {
   @PersistenceContext
   private EntityManager em;

--- a/src/test/java/com/sprint/monew/domain/activity/UserActivityMVCIntegrationTest.java
+++ b/src/test/java/com/sprint/monew/domain/activity/UserActivityMVCIntegrationTest.java
@@ -1,0 +1,139 @@
+package com.sprint.monew.domain.activity;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sprint.monew.MongoContainer;
+import com.sprint.monew.PostgresContainer;
+import com.sprint.monew.domain.article.repository.ArticleRepository;
+import com.sprint.monew.domain.interest.InterestRepository;
+import com.sprint.monew.domain.user.User;
+import com.sprint.monew.domain.user.UserRepository;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+@Testcontainers
+class UserActivityMVCIntegrationTest {
+
+  @LocalServerPort
+  private int port;
+
+  @BeforeAll
+  static void beforeAll() {
+    MongoContainer.getInstance().start();
+    PostgresContainer.getInstance().start();
+  }
+  @Autowired
+  private MockMvc mockMvc;
+
+  @DynamicPropertySource
+  static void setProperties(DynamicPropertyRegistry registry) {
+    // MongoDB 연결
+    registry.add("spring.data.mongodb.uri", MongoContainer.getInstance()::getReplicaSetUrl);
+
+    // PostgreSQL 연결
+    PostgresContainer postgres = PostgresContainer.getInstance();
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", postgres::getUsername);
+    registry.add("spring.datasource.password", postgres::getPassword);
+    registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+  }
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private InterestRepository interestRepository;
+
+  @Autowired
+  private ArticleRepository articleRepository;
+
+  private UUID testUserId;
+
+  @BeforeEach
+  void setUp() {
+    // 사용자 및 샘플 데이터 저장
+    User user = new User(
+        "test@email.com",
+        "nickname",
+        "password",
+        Instant.now(),
+        false);
+    userRepository.save(user);
+
+    testUserId = user.getId();
+  }
+
+  @Test
+  @DisplayName("성공 - 유저의 모든 활동 정보를 RDB에서 조회한다")
+  void testGetUserActivityFromQueryDb() throws Exception {
+    mockMvc.perform(get("/api/user-activity/{userId}/query", testUserId)
+            .header("Monew-Request-User-ID", testUserId))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("실패 - 존재하지 않는 유저의 정보를 RDB에서 조회한다")
+  void testGetNonExistsUserActivityFromQueryDb() throws Exception {
+    UUID nonExistentUserId = UUID.randomUUID();
+    mockMvc.perform(get("/api/user-activity/{userId}/query", nonExistentUserId)
+            .header("Monew-Request-User-ID", nonExistentUserId))
+        .andExpect(status().is5xxServerError());
+  }
+
+  @Test
+  @DisplayName("성공 - 유저의 모든 활동 정보를 MongoDB에 저장한다")
+  void testSaveUserActivityToMongo() throws Exception {
+    mockMvc.perform(get("/api/user-activity/{userId}/save", testUserId)
+            .header("Monew-Request-User-ID", testUserId))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("실패 - 존재하지 않는 유저의 정보를 MongoDB에 저장한다")
+  void testSaveNonExistsUserActivityToMongo() throws Exception {
+    UUID nonExistentUserId = UUID.randomUUID();
+    mockMvc.perform(get("/api/user-activity/{userId}/save", nonExistentUserId)
+            .header("Monew-Request-User-ID", nonExistentUserId))
+        .andExpect(status().is5xxServerError());
+  }
+
+  @Test
+  @DisplayName("실패 - mongoDB엔 유저가 존재하지 않지만 조회한다")
+  void testGetNonExistUserActivityFromMongo() throws Exception {
+    mockMvc.perform(get("/api/user-activity/{userId}", testUserId)
+            .header("Monew-Request-User-ID", testUserId))
+        .andExpect(status().is5xxServerError());
+//        .andExpect(jsonPath("$.userId").value(testUserId.toString()));
+  }
+
+  @Test
+  @DisplayName("성공 - 유저의 모든 활동 정보를 MongoDB에서 조회한다")
+  void testGetUserActivityFromMongo() throws Exception {
+    mockMvc.perform(get("/api/user-activity/{userId}/save", testUserId)
+            .header("Monew-Request-User-ID", testUserId))
+        .andExpect(status().isOk());
+    mockMvc.perform(get("/api/user-activity/{userId}", testUserId)
+            .header("Monew-Request-User-ID", testUserId))
+        .andExpect(status().isOk());
+  }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -6,6 +6,10 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  data:
+    mongodb:
+      uri: ${MONGODB_URI}
+      database: ${MONGODB_DATABASE}
 
   flyway:
     enabled: true


### PR DESCRIPTION
## 🛰️ Issue Number
- #84
## 🪐 작업 내용
- 기존 엔티티에 createAt이 자동으로 초기화되지 않던 것들 수정
- MongoDB에 저장하는 로직을 체크하는 테스트 추가
- MongoDB 테스트 구동을 위해 실행시 필요한 mongoDB URI 추가
- 유저의 활동내역을 업데이트하는 updateUserActivityToMongo 추가
## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
