### PR TITLE
feat: 알림 API 컨트롤러 및 예외 처리 구현, 알림 레포지토리 테스트 코드 추가

### DIFF
--- a/src/main/java/com/sprint/monew/domain/notification/NotificationController.java
+++ b/src/main/java/com/sprint/monew/domain/notification/NotificationController.java
@@ -1,11 +1,14 @@
 package com.sprint.monew.domain.notification;
 
 import com.sprint.monew.common.util.CursorPageResponseDto;
+import com.sprint.monew.domain.notification.dto.NotificationSearchRequest;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,23 +23,25 @@ public class NotificationController {
 
   // 알림 목록 조회
   @GetMapping
-  public ResponseEntity<CursorPageResponseDto> getNotifications() {
-    return null;
+  public ResponseEntity<CursorPageResponseDto> getNotifications(
+      NotificationSearchRequest request,
+      @RequestHeader("Monew-Request-User-ID") UUID userId) {
+    return ResponseEntity.ok(notificationService.getAllNotifications(request, userId));
   }
 
   // 전체 알림 확인
   @PatchMapping
-  public ResponseEntity<?> checkAllNotifications() {
-    //Monew-Request-User-ID는 헤더로 받음
-    return null;
+  public ResponseEntity<Void> checkAllNotifications(
+      @RequestHeader("Monew-Request-User-ID") UUID userId) {
+    notificationService.checkAllNotifications(userId);
+    return ResponseEntity.ok().build();
   }
 
   // 알림 확인(단일)
   @PatchMapping("/{notificationId}")
-  public ResponseEntity<?> checkNotification(@PathVariable String notificationId) {
-    //Monew-Request-User-ID는 헤더로 받음
-    return null;
+  public ResponseEntity<Void> checkNotification(@PathVariable UUID notificationId,
+      @RequestHeader("Monew-Request-User-ID") UUID userId) {
+    notificationService.checkNotification(notificationId, userId);
+    return ResponseEntity.ok().build();
   }
-
-
 }

--- a/src/main/java/com/sprint/monew/domain/notification/NotificationRepository.java
+++ b/src/main/java/com/sprint/monew/domain/notification/NotificationRepository.java
@@ -10,7 +10,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+public interface NotificationRepository extends JpaRepository<Notification, UUID>,
+    NotificationRepositoryCustom {
 
   List<Notification> findByUser(User user);
 

--- a/src/main/java/com/sprint/monew/domain/notification/NotificationRepository.java
+++ b/src/main/java/com/sprint/monew/domain/notification/NotificationRepository.java
@@ -32,7 +32,7 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
       Instant afterAt, Pageable pageable);
 
   @Query(
-      "SELECT n "
+      "SELECT COUNT(n) "
           + "FROM Notification n "
           + "WHERE n.user.id = :userId AND n.confirmed = false")
   int countUnconfirmedByUserId(UUID userId);

--- a/src/main/java/com/sprint/monew/domain/notification/NotificationRepositoryCustom.java
+++ b/src/main/java/com/sprint/monew/domain/notification/NotificationRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.sprint.monew.domain.notification;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+
+public interface NotificationRepositoryCustom {
+
+  List<Notification> getUnconfirmedWithCursor(UUID userId, UUID cursorId,
+      Instant afterAt, Pageable pageable);
+}

--- a/src/main/java/com/sprint/monew/domain/notification/NotificationRepositoryCustomImpl.java
+++ b/src/main/java/com/sprint/monew/domain/notification/NotificationRepositoryCustomImpl.java
@@ -1,0 +1,41 @@
+package com.sprint.monew.domain.notification;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@AllArgsConstructor
+public class NotificationRepositoryCustomImpl implements NotificationRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<Notification> getUnconfirmedWithCursor(UUID userId, UUID cursorId, Instant afterAt,
+      Pageable pageable) {
+
+    QNotification notification = QNotification.notification;
+
+    BooleanBuilder whereClause = new BooleanBuilder();
+
+    whereClause.and(notification.user.id.eq(userId)).and(notification.confirmed.isFalse());
+
+    if (cursorId != null && afterAt != null) {
+      whereClause.and(notification.createdAt.lt(afterAt)
+          .or(notification.createdAt.lt(afterAt).and(notification.id.lt(cursorId))));
+    }
+
+    return queryFactory.select(notification)
+        .from(notification)
+        .where(whereClause)
+        .orderBy(notification.createdAt.desc(), notification.id.desc())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+  }
+}

--- a/src/main/java/com/sprint/monew/domain/notification/NotificationService.java
+++ b/src/main/java/com/sprint/monew/domain/notification/NotificationService.java
@@ -101,7 +101,7 @@ public class NotificationService {
         .map(NotificationDto::from)
         .toList();
 
-    return new CursorPageResponseDto(
+    return new CursorPageResponseDto<>(
         notificationDtos,
         nextCursor,
         nextAfter,

--- a/src/main/java/com/sprint/monew/domain/notification/NotificationService.java
+++ b/src/main/java/com/sprint/monew/domain/notification/NotificationService.java
@@ -1,7 +1,6 @@
 package com.sprint.monew.domain.notification;
 
 import com.sprint.monew.common.util.CursorPageResponseDto;
-import com.sprint.monew.domain.interest.subscription.SubscriptionRepository;
 import com.sprint.monew.domain.notification.dto.NotificationSearchRequest;
 import com.sprint.monew.domain.notification.dto.UnreadInterestArticleCount;
 import com.sprint.monew.domain.notification.exception.NotificationNotFoundException;
@@ -23,7 +22,6 @@ public class NotificationService {
 
   private final NotificationRepository notificationRepository;
   private final UserRepository userRepository;
-  private final SubscriptionRepository subscriberRepository;
 
   //알림 등록 - 일괄 등록
   public List<Notification> createArticleInterestNotifications(
@@ -82,7 +80,7 @@ public class NotificationService {
     PageRequest pagerequest = PageRequest.of(0, limit + 1);
 
     List<Notification> notifications
-        = notificationRepository.findUnconfirmedWithCursor(userId, cursor, after,
+        = notificationRepository.getUnconfirmedWithCursor(userId, cursor, after,
         pagerequest);
 
     boolean hasNext = notifications.size() > limit;

--- a/src/main/java/com/sprint/monew/domain/notification/NotificationService.java
+++ b/src/main/java/com/sprint/monew/domain/notification/NotificationService.java
@@ -8,6 +8,7 @@ import com.sprint.monew.domain.user.User;
 import com.sprint.monew.domain.user.UserRepository;
 import com.sprint.monew.domain.user.exception.UserNotFoundException;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -28,14 +29,12 @@ public class NotificationService {
       List<UnreadInterestArticleCount> unreadInterestArticleCounts) {
 
     return unreadInterestArticleCounts.stream()
-        .map(un -> {
-          Notification notification = new Notification(
-              un.getUser(),
-              un.getInterest().getId(),
-              ResourceType.INTEREST,
-              un.getInterest().getName() + "와/과 관련된 기사가 " + un.getArticleCount() + "건 등록되었습니다.");
-          return notification;
-        }).toList();
+        .map(un -> new Notification(
+            un.getUser(),
+            un.getInterest().getId(),
+            ResourceType.INTEREST,
+            un.getInterest().getName() + "와/과 관련된 기사가 " + un.getArticleCount() + "건 등록되었습니다.")
+        ).toList();
   }
 
   //알림 수정 - 전체 알림 확인
@@ -87,6 +86,18 @@ public class NotificationService {
 
     if (hasNext) {
       notifications = notifications.subList(0, limit);
+    }
+
+    // 빈 리스트 처리
+    if (notifications.isEmpty()) {
+      return new CursorPageResponseDto<>(
+          Collections.emptyList(),
+          null,
+          null,
+          0,
+          0,
+          false
+      );
     }
 
     UUID nextCursor = notifications.get(notifications.size() - 1).getId();

--- a/src/main/java/com/sprint/monew/domain/notification/dto/NotificationSearchRequest.java
+++ b/src/main/java/com/sprint/monew/domain/notification/dto/NotificationSearchRequest.java
@@ -1,0 +1,12 @@
+package com.sprint.monew.domain.notification.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record NotificationSearchRequest(
+    UUID cursor,
+    Instant after,
+    Integer limit
+) {
+
+}

--- a/src/main/java/com/sprint/monew/domain/notification/exception/NotificationException.java
+++ b/src/main/java/com/sprint/monew/domain/notification/exception/NotificationException.java
@@ -1,0 +1,15 @@
+package com.sprint.monew.domain.notification.exception;
+
+import com.sprint.monew.global.error.ErrorCode;
+import com.sprint.monew.global.error.MonewException;
+
+public class NotificationException extends MonewException {
+
+  public NotificationException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public NotificationException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+}

--- a/src/main/java/com/sprint/monew/domain/notification/exception/NotificationNotFoundException.java
+++ b/src/main/java/com/sprint/monew/domain/notification/exception/NotificationNotFoundException.java
@@ -1,0 +1,18 @@
+package com.sprint.monew.domain.notification.exception;
+
+import com.sprint.monew.global.error.ErrorCode;
+import java.util.UUID;
+
+public class NotificationNotFoundException extends NotificationException {
+
+  public NotificationNotFoundException() {
+    super(ErrorCode.NOTIFICATION_NOT_FOUND);
+  }
+
+  public static NotificationNotFoundException notFound(UUID notificationId) {
+    NotificationNotFoundException exception = new NotificationNotFoundException();
+    exception.addDetail("notificationId", notificationId);
+    return exception;
+  }
+
+}

--- a/src/main/java/com/sprint/monew/global/error/ErrorCode.java
+++ b/src/main/java/com/sprint/monew/global/error/ErrorCode.java
@@ -17,6 +17,9 @@ public enum ErrorCode {
   INTEREST_NOT_FOUND("관심사 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   EMPTY_KEYWORDS_NOT_ALLOWED("키워드는 한 개 이상 포함되어야 합니다.", HttpStatus.BAD_REQUEST),
 
+  // Notification 관련 에러코드
+  NOTIFICATION_NOT_FOUND("알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
   // Article 관련 에러코드
   ARTICLE_NOT_FOUND("기사를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   ARTICLE_VIEW_ALREADY_EXIST("이미 존재하는 기사 뷰 입니다.", HttpStatus.CONFLICT),

--- a/src/test/java/com/sprint/monew/domain/notification/NotificationRepositoryTest.java
+++ b/src/test/java/com/sprint/monew/domain/notification/NotificationRepositoryTest.java
@@ -134,7 +134,6 @@ public class NotificationRepositoryTest {
   @DisplayName("확인 시간으로부터 일주일 된 알림 삭제")
   void deleteUnconfirmedNotification() {
     //given - 알림 읽은 시각 7일 +1초 전으로 업데이트 변경
-    //todo - deleteConfirmedNotificationsOlderThan()의 쿼리문에서 7일 계산해야하지 않을까?
     notification.confirm(Instant.now().minus(Duration.ofDays(7).plusSeconds(1)));
     em.flush();
 

--- a/src/test/java/com/sprint/monew/domain/notification/NotificationRepositoryTest.java
+++ b/src/test/java/com/sprint/monew/domain/notification/NotificationRepositoryTest.java
@@ -1,42 +1,149 @@
 package com.sprint.monew.domain.notification;
 
-import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sprint.monew.common.config.TestQuerydslConfig;
+import com.sprint.monew.domain.article.Article;
+import com.sprint.monew.domain.article.Article.Source;
+import com.sprint.monew.domain.article.articleinterest.ArticleInterest;
 import com.sprint.monew.domain.interest.Interest;
-import com.sprint.monew.domain.interest.InterestRepository;
-import com.sprint.monew.domain.interest.subscription.SubscriptionRepository;
-import com.sprint.monew.global.config.QueryDSLConfig;
+import com.sprint.monew.domain.interest.subscription.Subscription;
+import com.sprint.monew.domain.user.User;
+import jakarta.persistence.EntityManager;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @DataJpaTest
-@AutoConfigureTestDatabase(replace = Replace.NONE)
+@ExtendWith(SpringExtension.class)
+@Import({NotificationRepositoryCustomImpl.class, TestQuerydslConfig.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
-@Import(QueryDSLConfig.class)
 public class NotificationRepositoryTest {
 
   @Autowired
-  SubscriptionRepository subscriptionRepository;
+  private EntityManager em;
 
   @Autowired
-  InterestRepository interestRepository;
+  private NotificationRepository notificationRepository;
+
+  private User user;
+  private Interest interest;
+  private Notification notification;
+
+  @BeforeEach
+  void setUp() {
+    //사용자
+    String email = "test@example.com";
+    String nickname = "테스트유저";
+    String password = "test1234";
+    Instant createdAt = Instant.now();
+    boolean deleted = false;
+    user = new User(email, nickname, password, createdAt, deleted);
+    em.persist(user);
+
+    //기사
+    Article article = Article.create(Source.NAVER,
+        "https://news.example.com/tech/2025/04/23/article12345", "인공지능 기술의 최신 동향과 미래 전망",
+        Instant.parse("2025-04-22T15:30:00Z"),
+        "최근 인공지능 기술의 발전과 산업 적용 사례를 분석하고, 향후 5년간의 기술 발전 방향을 예측한 보고서입니다.");
+    em.persist(article);
+
+    //관심사
+    String name = "기술";
+    List<String> keywords = List.of("인공지능", "AI", "IT");
+    interest = new Interest(name, keywords);
+    em.persist(interest);
+
+    //기사-관심사
+    ArticleInterest articleInterest = ArticleInterest.create(
+        article, interest
+    );
+    em.persist(articleInterest);
+
+    //구독
+    Subscription subscription = new Subscription(user, interest);
+    em.persist(subscription);
+
+    //기존 알림 - 조회 및 삭제 테스트에 활용
+    notification = notificationRepository.save(new Notification(
+        user,
+        UUID.randomUUID(), // 임의의 리소스 ID
+        ResourceType.COMMENT,
+        "누군가 내 댓글에 좋아요를 눌렀어요."
+    ));
+    em.persist(notification);
+    em.flush();
+  }
+
 
   @Test
-  void testNotificationRepository() {
-    Instant now = Instant.now();
-    subscriptionRepository.findNewArticleCountWithUserInterest(now);
+  @DisplayName("미확인 알림 조회")
+  void getUnconfirmedNotifications() {
+
+    //given
+    int limit = 10;
+    PageRequest pageRequest = PageRequest.of(0, limit + 1);
+
+    //when
+    List<Notification> unconfirmedWithCursor = notificationRepository.getUnconfirmedWithCursor(
+        user.getId(), null, null, pageRequest);
+
+    //then
+    assertEquals(1, unconfirmedWithCursor.size());
   }
 
   @Test
-  void testInterestRepository() {
-    List<Interest> all = interestRepository.findAll();
-    System.out.println("all = " + all);
+  @DisplayName("미확인 알림 총 개수 조회")
+  void getUnconfirmedNotificationsCount() {
+    //when
+    int count = notificationRepository.countUnconfirmedByUserId(user.getId());
+    assertEquals(1, count);
   }
+
+  @Test
+  @DisplayName("알림 읽음으로 수정 후 조회")
+  void updateUnconfirmedNotifications() {
+    //given
+    notification.confirm(Instant.now());
+    em.flush();
+
+    //when
+    int count = notificationRepository.countUnconfirmedByUserId(user.getId());
+
+    //then
+    assertEquals(0, count);
+    assertEquals(0, notificationRepository.countUnconfirmedByUserId(user.getId()));
+
+  }
+
+  @Test
+  @DisplayName("확인 시간으로부터 일주일 된 알림 삭제")
+  void deleteUnconfirmedNotification() {
+    //given - 알림 읽은 시각 7일 +1초 전으로 업데이트 변경
+    //todo - deleteConfirmedNotificationsOlderThan()의 쿼리문에서 7일 계산해야하지 않을까?
+    notification.confirm(Instant.now().minus(Duration.ofDays(7).plusSeconds(1)));
+    em.flush();
+
+    //when
+    notificationRepository.deleteConfirmedNotificationsOlderThan(Instant.now());
+
+    //then
+    assertEquals(0, notificationRepository.countUnconfirmedByUserId(user.getId()));
+    assertTrue(notificationRepository.findById(notification.getId()).isEmpty());
+  }
+
 }

--- a/src/test/java/com/sprint/monew/domain/notification/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/monew/domain/notification/NotificationServiceTest.java
@@ -3,16 +3,12 @@ package com.sprint.monew.domain.notification;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.sprint.monew.common.util.CursorPageResponseDto;
 import com.sprint.monew.domain.article.Article;
 import com.sprint.monew.domain.article.Article.Source;
-import com.sprint.monew.domain.comment.Comment;
-import com.sprint.monew.domain.comment.like.Like;
 import com.sprint.monew.domain.interest.Interest;
-import com.sprint.monew.domain.interest.subscription.SubscriptionRepository;
 import com.sprint.monew.domain.notification.dto.NotificationSearchRequest;
 import com.sprint.monew.domain.notification.dto.UnreadInterestArticleCount;
 import com.sprint.monew.domain.user.User;
@@ -39,10 +35,6 @@ class NotificationServiceTest {
 
   @Mock
   private NotificationRepository notificationRepository;
-
-  @Mock
-  private SubscriptionRepository subscriberRepository;
-
 
   @Mock
   private UserRepository userRepository;
@@ -92,33 +84,21 @@ class NotificationServiceTest {
       Interest interest = interests.get(0);
 
       //기사 관심사 등록
-      Article article = Article.create(
-          Source.NAVER,
-          "https://news.example.com/tech/2025/04/23/article12345",
-          "인공지능 기술의 최신 동향과 미래 전망",
+      Article article = Article.create(Source.NAVER,
+          "https://news.example.com/tech/2025/04/23/article12345", "인공지능 기술의 최신 동향과 미래 전망",
           Instant.parse("2025-04-22T15:30:00Z"),
-          "최근 인공지능 기술의 발전과 산업 적용 사례를 분석하고, 향후 5년간의 기술 발전 방향을 예측한 보고서입니다."
-      );
+          "최근 인공지능 기술의 발전과 산업 적용 사례를 분석하고, 향후 5년간의 기술 발전 방향을 예측한 보고서입니다.");
 
       //ArticleInterest 생성
       article.addInterest(interest);
 
       List<UnreadInterestArticleCount> queryResult = new ArrayList<>();
-      queryResult.add(new TestUnreadInterestArticleCount(
-          interest,
-          user,
-          1L
-      ));
-
-      when(subscriberRepository.findNewArticleCountWithUserInterest(afterAt))
-          .thenReturn(queryResult);
+      queryResult.add(new TestUnreadInterestArticleCount(interest, user, 1L));
 
       NotificationDto expectedNotification = NotificationDto.from(
-          new Notification(user,
-              interest.getId(),
-              ResourceType.INTEREST,
-              queryResult.get(0).getInterest().getName() + "와/과 관련된 기사가 "
-                  + queryResult.get(0).getArticleCount() + "건 등록되었습니다."));
+          new Notification(user, interest.getId(), ResourceType.INTEREST,
+              queryResult.get(0).getInterest().getName() + "와/과 관련된 기사가 " + queryResult.get(0)
+                  .getArticleCount() + "건 등록되었습니다."));
 
       //todo - 테스트코드 수정
       //when
@@ -133,27 +113,8 @@ class NotificationServiceTest {
 //      assertEquals(expectedNotification.content(), notifications.get(0).getContent());
 //      assertFalse(expectedNotification.confirmed());
     }
-
-
-    @Test
-    @DisplayName("성공: 내가 작성한 댓글에 좋아요 눌림")
-    void createNotificationMyCommentSuccess() {
-      //given
-      Instant afterAt = Instant.now();
-
-      Comment comment = mock(Comment.class);
-      Like like = new Like();
-      like.setUser(user);
-      like.setComment(comment);
-
-      //유저가 가지고있는 마지막 좋아요 알림 시간보다 이후에 생성된 좋아요
-
-      //when
-
-    }
-
-
   }
+
 
   @Nested
   @DisplayName("알림 수정")
@@ -171,8 +132,7 @@ class NotificationServiceTest {
       //given
       Interest interest = interests.get(0);
 
-      NotificationSearchRequest request
-          = new NotificationSearchRequest(null, null, 50);
+      NotificationSearchRequest request = new NotificationSearchRequest(null, null, 50);
 
       UUID userId = user.getId();
 
@@ -183,13 +143,13 @@ class NotificationServiceTest {
           interest.getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다."));
 
       when(userRepository.findById(userId)).thenReturn(Optional.ofNullable(user));
-      when(notificationRepository
-          .findUnconfirmedWithCursor(userId, request.cursor(), request.after(), pageRequest))
-          .thenReturn(expectNotifications);
+      when(
+          notificationRepository.getUnconfirmedWithCursor(userId, request.cursor(), request.after(),
+              pageRequest)).thenReturn(expectNotifications);
 
       //when
-      CursorPageResponseDto<NotificationDto> allNotifications
-          = notificationService.getAllNotifications(request, userId);
+      CursorPageResponseDto<NotificationDto> allNotifications = notificationService.getAllNotifications(
+          request, userId);
 
       //then
       assertEquals(expectNotifications.get(0).getId(), allNotifications.content().get(0).id());
@@ -213,8 +173,7 @@ class NotificationServiceTest {
     void getNotificationHasNextTrueSuccess() {
       //given
 
-      NotificationSearchRequest request
-          = new NotificationSearchRequest(null, null, 1);
+      NotificationSearchRequest request = new NotificationSearchRequest(null, null, 1);
 
       UUID userId = user.getId();
 
@@ -223,11 +182,9 @@ class NotificationServiceTest {
       List<Notification> expectNotifications = new ArrayList<>();
 
       Notification notification1 = new Notification(user, interests.get(0).getId(),
-          ResourceType.INTEREST,
-          interests.get(0).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
+          ResourceType.INTEREST, interests.get(0).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
       Notification notification2 = new Notification(user, interests.get(1).getId(),
-          ResourceType.INTEREST,
-          interests.get(1).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
+          ResourceType.INTEREST, interests.get(1).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
 
       UUID notificationId1 = UUID.randomUUID();
       UUID notificationId2 = UUID.randomUUID();
@@ -241,13 +198,13 @@ class NotificationServiceTest {
       expectNotifications.sort(Comparator.comparing(Notification::getCreatedAt).reversed());
 
       when(userRepository.findById(userId)).thenReturn(Optional.ofNullable(user));
-      when(notificationRepository
-          .findUnconfirmedWithCursor(userId, request.cursor(), request.after(), pageRequest))
-          .thenReturn(expectNotifications);
+      when(
+          notificationRepository.getUnconfirmedWithCursor(userId, request.cursor(), request.after(),
+              pageRequest)).thenReturn(expectNotifications);
 
       //when
-      CursorPageResponseDto<NotificationDto> allNotifications
-          = notificationService.getAllNotifications(request, userId);
+      CursorPageResponseDto<NotificationDto> allNotifications = notificationService.getAllNotifications(
+          request, userId);
 
       //then
       assertEquals(notification2.getId(), allNotifications.nextCursor());
@@ -260,23 +217,23 @@ class NotificationServiceTest {
     @DisplayName("성공: 다음 페이지 있고 커서 없음 (cursor not null / afterAt not null / limit 1)")
     void getNotificationHasNextTrueWithCursorSuccess() {
       //given
-      NotificationSearchRequest request
-          = new NotificationSearchRequest(null, null, 1);
       UUID userId = user.getId();
-
-      PageRequest pageRequest = PageRequest.of(0, request.limit() + 1);
 
       List<Notification> expectNotifications = new ArrayList<>();
 
       Notification notification1 = new Notification(user, interests.get(0).getId(),
-          ResourceType.INTEREST,
-          interests.get(0).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
+          ResourceType.INTEREST, interests.get(0).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
       Notification notification2 = new Notification(user, interests.get(1).getId(),
-          ResourceType.INTEREST,
-          interests.get(1).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
+          ResourceType.INTEREST, interests.get(1).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
 
       UUID notificationId1 = UUID.randomUUID();
       UUID notificationId2 = UUID.randomUUID();
+
+      UUID cursor = notification2.getId();
+      Instant afterAt = notification2.getCreatedAt();
+
+      NotificationSearchRequest request = new NotificationSearchRequest(cursor, afterAt, 1);
+      PageRequest pageRequest = PageRequest.of(0, request.limit() + 1);
 
       ReflectionTestUtils.setField(notification1, "id", notificationId1);
       ReflectionTestUtils.setField(notification2, "id", notificationId2);
@@ -287,17 +244,13 @@ class NotificationServiceTest {
       expectNotifications.sort(Comparator.comparing(Notification::getCreatedAt).reversed());
       expectNotifications.remove(expectNotifications.size() - 1 - request.limit());
 
-      UUID cursor = notification2.getId();
-      Instant afterAt = notification2.getCreatedAt();
-
       when(userRepository.findById(userId)).thenReturn(Optional.ofNullable(user));
-      when(notificationRepository
-          .findUnconfirmedWithCursor(userId, cursor, afterAt, pageRequest))
-          .thenReturn(expectNotifications);
+      when(notificationRepository.getUnconfirmedWithCursor(userId, cursor, afterAt,
+          pageRequest)).thenReturn(expectNotifications);
 
       //when
-      CursorPageResponseDto<NotificationDto> allNotifications
-          = notificationService.getAllNotifications(request, userId);
+      CursorPageResponseDto<NotificationDto> allNotifications = notificationService.getAllNotifications(
+          request, userId);
 
       //then
       assertEquals(notification1.getId(), allNotifications.nextCursor());


### PR DESCRIPTION
## 🛰️ Issue Number
- #85 
- #146

## 🪐 작업 내용
### 1. Notification Controller 구현
- 알림 전체 조회: GET /api/notifications
- 알림 전체 확인: PATCH /api/notifications
- 알림 단일 확인: PATCH /api/notifications/{notificationId}

### 2. 알림 예외 처리
- NotificationNotFound 예외 및 에러코드 추가
- 그 외 알림 기능에서 사용자를 찾을 수 없어 발생하는 예외는 사용자 예외 및 에러코드로 처리

### 3. 알림 조회 페이지네이션 Refactoring
- QueryDsl 적용하여 페이지네이션 조회 기능 리팩토링

### 4. 알림 레포지토리 테스트 코드 구현
- 미확인 알림 조회
- 미확인 알림 총 개수 조회
- 알림 읽음으로 수정 후 조회
- 확인 시간으로부터 일주일 된 알림 삭제 

## 📚 Reference
- [QueryDSL 기초 강의](https://www.youtube.com/watch?v=t4sCLuqLk8Q)

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
