### PR TITLE
fix : repository테스트 testcontainers에서 하도록 수정

### DIFF
--- a/src/main/java/com/sprint/monew/MonewApplication.java
+++ b/src/main/java/com/sprint/monew/MonewApplication.java
@@ -1,11 +1,14 @@
 package com.sprint.monew;
 
+import com.sprint.monew.domain.activity.UserActivityMongoRepository;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableMongoRepositories(basePackageClasses = UserActivityMongoRepository.class)
 public class MonewApplication {
 
   public static void main(String[] args) {

--- a/src/test/java/com/sprint/monew/domain/interest/InterestRepositoryTest.java
+++ b/src/test/java/com/sprint/monew/domain/interest/InterestRepositoryTest.java
@@ -2,6 +2,7 @@ package com.sprint.monew.domain.interest;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.sprint.monew.PostgresContainer;
 import com.sprint.monew.common.config.TestQuerydslConfig;
 import com.sprint.monew.domain.interest.subscription.Subscription;
 import com.sprint.monew.domain.user.User;
@@ -17,14 +18,30 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @DataJpaTest
 @ExtendWith(SpringExtension.class)
 @ActiveProfiles("test")
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
 @Import({CustomInterestRepositoryImpl.class, TestQuerydslConfig.class})
 public class InterestRepositoryTest {
+
+  static final PostgresContainer postgresContainer = PostgresContainer.getInstance();
+
+  static {
+    postgresContainer.start();
+  }
+
+  @DynamicPropertySource
+  static void overrideDataSourceProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgresContainer::getJdbcUrl);
+    registry.add("spring.datasource.username", postgresContainer::getUsername);
+    registry.add("spring.datasource.password", postgresContainer::getPassword);
+  }
 
   @Autowired
   private EntityManager em;

--- a/src/test/java/com/sprint/monew/domain/notification/NotificationRepositoryTest.java
+++ b/src/test/java/com/sprint/monew/domain/notification/NotificationRepositoryTest.java
@@ -3,6 +3,7 @@ package com.sprint.monew.domain.notification;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.sprint.monew.PostgresContainer;
 import com.sprint.monew.common.config.TestQuerydslConfig;
 import com.sprint.monew.domain.article.Article;
 import com.sprint.monew.domain.article.Article.Source;
@@ -25,14 +26,30 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @DataJpaTest
 @ExtendWith(SpringExtension.class)
 @Import({NotificationRepositoryCustomImpl.class, TestQuerydslConfig.class})
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
 @ActiveProfiles("test")
 public class NotificationRepositoryTest {
+
+  static final PostgresContainer postgresContainer = PostgresContainer.getInstance();
+
+  static {
+    postgresContainer.start();
+  }
+
+  @DynamicPropertySource
+  static void overrideDataSourceProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgresContainer::getJdbcUrl);
+    registry.add("spring.datasource.username", postgresContainer::getUsername);
+    registry.add("spring.datasource.password", postgresContainer::getPassword);
+  }
 
   @Autowired
   private EntityManager em;


### PR DESCRIPTION
## 🛰️ Issue Number

#155 

## 🪐 작업 내용
### Repository 테스트 테스트 컨테이너에서 하게 수정

### MongoDB 가 알아볼 수 있게 설정하라는info 안뜨게 하기
![image](https://github.com/user-attachments/assets/5c11f00d-6dcc-44fc-a70e-33474a7c73f7)

![image](https://github.com/user-attachments/assets/db6f6674-43d6-4da2-84fa-8d33e8a62336)

`@EnableMongoRepositories(basePackageClasses = UserActivityMongoRepository.class)`

## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
