### PR TITLE
fix : batch yml 스키마 초기화 설정 수정 + 리스너에 불필요한 애노테이션 삭제

### DIFF
--- a/src/main/java/com/sprint/monew/common/batch/config/ExecutionContextCleanupListenerConfig.java
+++ b/src/main/java/com/sprint/monew/common/batch/config/ExecutionContextCleanupListenerConfig.java
@@ -18,25 +18,21 @@ import org.springframework.context.annotation.Configuration;
 public class ExecutionContextCleanupListenerConfig {
 
   @Bean(name = "naverContextCleanupListener")
-  @StepScope
   public StepExecutionListener naverContextCleanupListener() {
     return new stepExecutionContextCleanupListener(NAVER_ARTICLE_DTOS.getKey());
   }
 
   @Bean(name = "chosunContextCleanupListener")
-  @StepScope
   public StepExecutionListener chosunContextCleanupListener() {
     return new stepExecutionContextCleanupListener(CHOSUN_ARTICLE_DTOS.getKey());
   }
 
   @Bean(name = "hankyungContextCleanupListener")
-  @StepScope
   public StepExecutionListener hankyungContextCleanupListener() {
     return new stepExecutionContextCleanupListener(HANKYUNG_ARTICLE_DTOS.getKey());
   }
 
   @Bean(name = "articleCollectJobContextCleanupListener")
-  @StepScope
   public JobExecutionListener articleCollectJobContextCleanupListener() {
     return new jobExecutionContextCleanupListener();
   }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -11,8 +11,8 @@ spring:
       hibernate:
         format_sql: true
   batch:
-      job:
-        initialize-schema: never
+    jdbc:
+      initialize-schema: never
   data:
     mongodb:
       uri: ${MONGODB_URI}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -11,7 +11,7 @@ spring:
       hibernate:
         format_sql: false
   batch:
-    job:
+    jdbc:
       initialize-schema: never
   data:
     mongodb:

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -15,6 +15,10 @@ spring:
     baseline-on-migrate: true
     clean-disabled: false
 
+  batch:
+    jdbc:
+      initialize-schema: never
+
 logging:
   level:
     com.sprint.mission.discodeit: debug


### PR DESCRIPTION
## 🛰️ Issue Number
- #161

# 📝 modification
> [FIX] : 스프링 batch yml depreciated된 설정 fix 

- yml 수정 
  - 스키마 initalize 설정 수정 
 
- 배치 리스너에 불필요한 stepScope 애노테이션 삭제 
  - 현재는 문제가 없지만, 프로메테우스를 도입했을 떄 순서 문제가 발생하기 떄문

## 🪐 작업 내용

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
