### PR TITLE
test: 테스트 코드 mongoTemplate Bean 불러올 수 없는 오류 수정

### DIFF
--- a/src/test/java/com/sprint/monew/domain/activity/UserActivityQueryRepositoryTest.java
+++ b/src/test/java/com/sprint/monew/domain/activity/UserActivityQueryRepositoryTest.java
@@ -8,9 +8,9 @@ import com.sprint.monew.domain.article.Article;
 import com.sprint.monew.domain.article.Article.Source;
 import com.sprint.monew.domain.article.articleview.ArticleView;
 import com.sprint.monew.domain.comment.Comment;
+import com.sprint.monew.domain.comment.like.Like;
 import com.sprint.monew.domain.interest.Interest;
 import com.sprint.monew.domain.interest.subscription.Subscription;
-import com.sprint.monew.domain.comment.like.Like;
 import com.sprint.monew.domain.user.User;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -35,6 +36,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @DataJpaTest
 @ExtendWith(SpringExtension.class)
 @Import({UserActivityQueryRepository.class, TestQuerydslConfig.class})
+@AutoConfigureDataMongo
 class UserActivityQueryRepositoryTest {
 
   @Container

--- a/src/test/java/com/sprint/monew/domain/comment/CommentRepositoryTest.java
+++ b/src/test/java/com/sprint/monew/domain/comment/CommentRepositoryTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
@@ -37,6 +38,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @DataJpaTest
 @ExtendWith(SpringExtension.class)
 @Import({CommentRepositoryImpl.class, TestQuerydslConfig.class})
+@AutoConfigureDataMongo
 public class CommentRepositoryTest {
 
   @Container
@@ -146,7 +148,6 @@ public class CommentRepositoryTest {
     PageRequest pageRequest = PageRequest.of(0, 3, Direction.DESC, "likeCount");
 
     Slice<CommentDto> page = commentRepository.getComments(request, userId, pageRequest);
-
 
     assertThat(page.hasNext()).isTrue();
     assertThat(page.getSize()).isEqualTo(3);

--- a/src/test/java/com/sprint/monew/domain/interest/InterestIntegrationTest.java
+++ b/src/test/java/com/sprint/monew/domain/interest/InterestIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sprint.monew.MongoContainer;
 import com.sprint.monew.PostgresContainer;
 import com.sprint.monew.domain.interest.dto.InterestCreateRequest;
 import com.sprint.monew.domain.interest.dto.InterestSearchRequest;
@@ -49,9 +50,11 @@ public class InterestIntegrationTest {
   private ObjectMapper objectMapper;
 
   static final PostgresContainer postgresContainer = PostgresContainer.getInstance();
+  static final MongoContainer mongoContainer = MongoContainer.getInstance();
 
   static {
     postgresContainer.start();
+    mongoContainer.start();
   }
 
   @DynamicPropertySource
@@ -59,6 +62,8 @@ public class InterestIntegrationTest {
     registry.add("spring.datasource.url", postgresContainer::getJdbcUrl);
     registry.add("spring.datasource.username", postgresContainer::getUsername);
     registry.add("spring.datasource.password", postgresContainer::getPassword);
+
+    registry.add("spring.data.mongodb.uri", MongoContainer.getInstance()::getReplicaSetUrl);
   }
 
   @Nested
@@ -142,7 +147,7 @@ public class InterestIntegrationTest {
   @DisplayName("관심사 구독")
   class interestSubscribe {
 
-    //@Test
+    @Test
     @DisplayName("성공")
     void success() throws Exception {
       //given
@@ -223,7 +228,7 @@ public class InterestIntegrationTest {
           .andExpect(status().isNotFound());
     }
 
-    //@Test
+    @Test
     @DisplayName("실패: 해당 ID의 관심사가 존재하지 않음")
     void failureSinceInterestId() throws Exception {
       //given
@@ -258,7 +263,7 @@ public class InterestIntegrationTest {
   @DisplayName("관심사 구독 취소")
   class interestUnsubscribe {
 
-    //@Test
+    @Test
     @DisplayName("성공")
     void success() throws Exception {
       //given
@@ -315,7 +320,7 @@ public class InterestIntegrationTest {
           .andExpect(status().isOk());
     }
 
-    //@Test
+    @Test
     @DisplayName("실패: 해당 ID의 사용자가 존재하지 않음")
     void failureSinceUserId() throws Exception {
       //given
@@ -375,7 +380,7 @@ public class InterestIntegrationTest {
           .andExpect(status().isNotFound());
     }
 
-    //@Test
+    @Test
     @DisplayName("실패: 해당 ID의 관심사가 존재하지 않음")
     void failureSinceInterestId() throws Exception {
       //given
@@ -629,7 +634,6 @@ public class InterestIntegrationTest {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.content").isArray())
           .andExpect(jsonPath("$.totalElements").isNumber());
-
     }
   }
 }

--- a/src/test/java/com/sprint/monew/domain/interest/InterestRepositoryTest.java
+++ b/src/test/java/com/sprint/monew/domain/interest/InterestRepositoryTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
@@ -34,6 +35,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @ActiveProfiles("test")
 @Testcontainers
 @Import({CustomInterestRepositoryImpl.class, TestQuerydslConfig.class})
+@AutoConfigureDataMongo
 //@Sql(scripts = "/seed-test.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 public class InterestRepositoryTest {
 

--- a/src/test/java/com/sprint/monew/domain/notification/NotificationRepositoryTest.java
+++ b/src/test/java/com/sprint/monew/domain/notification/NotificationRepositoryTest.java
@@ -19,23 +19,21 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @DataJpaTest
-@ExtendWith(SpringExtension.class)
 @Import({NotificationRepositoryCustomImpl.class, TestQuerydslConfig.class})
 @Testcontainers
 @ActiveProfiles("test")
+@AutoConfigureDataMongo
 public class NotificationRepositoryTest {
 
   static final PostgresContainer postgresContainer = PostgresContainer.getInstance();

--- a/src/test/java/com/sprint/monew/domain/user/UserRepositoryTest.java
+++ b/src/test/java/com/sprint/monew/domain/user/UserRepositoryTest.java
@@ -8,10 +8,10 @@ import com.sprint.monew.domain.activity.UserActivityQueryRepository;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
@@ -23,6 +23,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @DataJpaTest
 @Testcontainers
 @ActiveProfiles("test")
+@AutoConfigureDataMongo
 @Import({UserActivityQueryRepository.class, TestQuerydslConfig.class})
 class UserRepositoryTest {
 

--- a/src/test/java/com/sprint/monew/integration/UserIntegrationTest.java
+++ b/src/test/java/com/sprint/monew/integration/UserIntegrationTest.java
@@ -1,15 +1,15 @@
 package com.sprint.monew.integration;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sprint.monew.MongoContainer;
 import com.sprint.monew.PostgresContainer;
 import com.sprint.monew.domain.user.UserLoginRequest;
 import com.sprint.monew.domain.user.UserRegisterRequest;
@@ -43,9 +43,11 @@ public class UserIntegrationTest {
   private ObjectMapper objectMapper;
 
   static final PostgresContainer postgresContainer = PostgresContainer.getInstance();
+  static final MongoContainer mongoContainer = MongoContainer.getInstance();
 
   static {
     postgresContainer.start();
+    mongoContainer.start();
   }
 
   @DynamicPropertySource
@@ -53,6 +55,8 @@ public class UserIntegrationTest {
     registry.add("spring.datasource.url", postgresContainer::getJdbcUrl);
     registry.add("spring.datasource.username", postgresContainer::getUsername);
     registry.add("spring.datasource.password", postgresContainer::getPassword);
+
+    registry.add("spring.data.mongodb.uri", MongoContainer.getInstance()::getReplicaSetUrl);
   }
 
   @Test


### PR DESCRIPTION
## 🛰️ Issue Number
- #164 

## 🪐 작업 내용
- #164 에 상세히 설명해두었습니다.

### 요약
- 각 도메인 레포지토리 테스트가 모두 제대로 작동하지 않는 오류 수정
  - @EnableMongoRepositories추가에 따라, 레포지토리들은 MongoDB 설정이 필요해졌음. @DataJpaTest는 기본적으로 JPA 관련 빈만 구성하고 다른 데이터 액세스 기술(MongoDB 등)은 비활성화하여 문제 발생. @AutoConfigureDataMongo를 추가하여 MongoDB 관련 Bean을 생성할 수 있도록 수정하였음.

## 📚 Reference
- https://stackoverflow.com/questions/56146773/is-the-annotation-enablemongorepositories-required-while-creating-rest-endpoint
- Claud.ai 도움

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
