### PR TITLE
bug : photo가 article로 인식되는 오류 해결 

### DIFF
--- a/src/main/java/com/sprint/monew/common/batch/support/InterestContainer.java
+++ b/src/main/java/com/sprint/monew/common/batch/support/InterestContainer.java
@@ -29,10 +29,15 @@ public class InterestContainer {
   }
 
   public ArticleApiDto filter(ArticleApiDto articleApiDto) {
-    if (isContainKeywords(articleApiDto.summary()) && isNewUrl(articleApiDto.sourceUrl())) {
+    if (isContainKeywords(articleApiDto.summary()) && isNewUrl(articleApiDto.sourceUrl())
+        && !isPhoto(articleApiDto.sourceUrl())) {
       return articleApiDto;
     }
     return null;
+  }
+
+  private boolean isPhoto(String sourceUrl) {
+    return sourceUrl.contains("photos");
   }
 
   private boolean isNewUrl(String sourceUrl) {


### PR DESCRIPTION
## 🛰️ Issue Number
- #187

## 🪐 작업 내용
naver 기사 수집시 photo url관련해서 따로 articleApiDto로 전달되는거 필터링

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
