### PR TITLE
fix: 알림 테스트 코드 주석 제거 및 수정, 관심사 버그 수정 

### DIFF
--- a/src/main/java/com/sprint/monew/domain/interest/InterestService.java
+++ b/src/main/java/com/sprint/monew/domain/interest/InterestService.java
@@ -131,6 +131,14 @@ public class InterestService {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> UserNotFoundException.withId(userId));
 
+    Subscription subscription = subscriptionRepository.findByUserAndInterest(user, interest)
+        .orElse(null);
+
+    if (subscription != null) {
+      return SubscriptionDto.from(subscription,
+          subscriptionRepository.countDistinctByInterestId(interestId));
+    }
+
     Subscription subscribe = new Subscription(user, interest);
     subscriptionRepository.save(subscribe);
 

--- a/src/main/java/com/sprint/monew/domain/interest/dto/InterestCreateRequest.java
+++ b/src/main/java/com/sprint/monew/domain/interest/dto/InterestCreateRequest.java
@@ -1,6 +1,7 @@
 package com.sprint.monew.domain.interest.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
@@ -11,7 +12,7 @@ public record InterestCreateRequest(
 
     @Schema(description = "관련 키워드 목록")
     @Size(min = 1, max = 10)
-    List<String> keywords
+    List<@NotBlank @Size(min = 1, max = 20) String> keywords
 ) {
 
 }

--- a/src/main/java/com/sprint/monew/domain/interest/dto/InterestUpdateRequest.java
+++ b/src/main/java/com/sprint/monew/domain/interest/dto/InterestUpdateRequest.java
@@ -1,10 +1,12 @@
 package com.sprint.monew.domain.interest.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record InterestUpdateRequest(
-    @Size(min = 1, max = 10) List<String> keywords
+    @Size(min = 1, max = 10)
+    List<@NotBlank @Size(min = 1, max = 20) String> keywords
 ) {
 
 }

--- a/src/main/java/com/sprint/monew/domain/notification/Notification.java
+++ b/src/main/java/com/sprint/monew/domain/notification/Notification.java
@@ -4,6 +4,7 @@ package com.sprint.monew.domain.notification;
 import com.sprint.monew.domain.user.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
@@ -18,14 +19,16 @@ import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @Setter
 @Table(name = "notifications")
 @Entity
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class Notification {
 
   @Id
@@ -47,8 +50,8 @@ public class Notification {
   @Column(nullable = false)
   private String content;
 
-  @CreationTimestamp
-  @Column(nullable = false)
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
   private Instant createdAt;
 
   @LastModifiedDate
@@ -63,13 +66,10 @@ public class Notification {
     this.resourceId = resourceId;
     this.resourceType = resourceType;
     this.content = content;
-    this.createdAt = Instant.now();
-    this.updatedAt = createdAt;
     this.confirmed = false;
   }
 
-  public void confirm(Instant updatedAt) {
+  public void confirm() {
     this.confirmed = true;
-    this.updatedAt = updatedAt;
   }
 }

--- a/src/main/java/com/sprint/monew/domain/notification/NotificationService.java
+++ b/src/main/java/com/sprint/monew/domain/notification/NotificationService.java
@@ -44,13 +44,10 @@ public class NotificationService {
         .orElseThrow(() -> UserNotFoundException.withId(userId));
 
     List<Notification> notifications = notificationRepository.findByUser(user);
-    Instant updatedAt = Instant.now();
 
     log.debug("미확인 알림 수 = {}", notifications.size());
 
-    notifications.forEach(n -> {
-      n.confirm(updatedAt);
-    });
+    notifications.forEach(Notification::confirm);
 
     notificationRepository.saveAll(notifications);
 
@@ -71,7 +68,7 @@ public class NotificationService {
 
     log.debug("확인 여부 = {}", notification.isConfirmed());
 
-    notification.confirm(Instant.now());
+    notification.confirm();
     notificationRepository.save(notification);
 
     log.info("알림 수정-단일 알림 확인 완료. 확인 여부 = {}, 확인 시각 = {}", notification.isConfirmed(),
@@ -88,7 +85,7 @@ public class NotificationService {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> UserNotFoundException.withId(userId));
 
-    int limit = (request.limit() == null || request.limit() <= 0) ? 30 : request.limit();
+    int limit = request.limit();
     UUID cursor = request.cursor();
     Instant after = request.after();
 

--- a/src/test/java/com/sprint/monew/domain/notification/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/monew/domain/notification/NotificationServiceTest.java
@@ -357,6 +357,12 @@ class NotificationServiceTest {
       Notification notification2 = new Notification(user, interests.get(1).getId(),
           ResourceType.INTEREST, interests.get(1).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
 
+      notification1.setCreatedAt(Instant.now());
+      notification1.setUpdatedAt(Instant.now());
+
+      notification2.setCreatedAt(Instant.now());
+      notification2.setUpdatedAt(Instant.now());
+
       UUID notificationId1 = UUID.randomUUID();
       UUID notificationId2 = UUID.randomUUID();
 
@@ -399,6 +405,12 @@ class NotificationServiceTest {
 
       UUID notificationId1 = UUID.randomUUID();
       UUID notificationId2 = UUID.randomUUID();
+
+      notification1.setCreatedAt(Instant.now());
+      notification1.setUpdatedAt(Instant.now());
+
+      notification2.setCreatedAt(Instant.now());
+      notification2.setUpdatedAt(Instant.now());
 
       UUID cursor = notification2.getId();
       Instant afterAt = notification2.getCreatedAt();

--- a/src/test/java/com/sprint/monew/domain/notification/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/monew/domain/notification/NotificationServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import com.sprint.monew.common.batch.support.NotificationJdbc;
 import com.sprint.monew.common.util.CursorPageResponseDto;
@@ -25,6 +26,7 @@ import com.sprint.monew.domain.user.UserRepository;
 import com.sprint.monew.domain.user.exception.UserNotFoundException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -336,96 +338,96 @@ class NotificationServiceTest {
           allNotifications.content().get(0).content());
 
     }
-//
-//    @Test
-//    @DisplayName("성공: 다음 페이지 있음 (cursor null / afterAt null / limit 1)")
-//    void getNotificationHasNextTrueSuccess() {
-//      //given
-//
-//      NotificationSearchRequest request = new NotificationSearchRequest(null, null, 1);
-//
-//      UUID userId = user.getId();
-//
-//      PageRequest pageRequest = PageRequest.of(0, request.limit() + 1);
-//
-//      List<Notification> expectNotifications = new ArrayList<>();
-//
-//      Notification notification1 = new Notification(user, interests.get(0).getId(),
-//          ResourceType.INTEREST, interests.get(0).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
-//      Notification notification2 = new Notification(user, interests.get(1).getId(),
-//          ResourceType.INTEREST, interests.get(1).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
-//
-//      UUID notificationId1 = UUID.randomUUID();
-//      UUID notificationId2 = UUID.randomUUID();
-//
-//      ReflectionTestUtils.setField(notification1, "id", notificationId1);
-//      ReflectionTestUtils.setField(notification2, "id", notificationId2);
-//
-//      expectNotifications.add(notification1);
-//      expectNotifications.add(notification2);
-//
-//      expectNotifications.sort(Comparator.comparing(Notification::getCreatedAt).reversed());
-//
-//      when(userRepository.findById(userId)).thenReturn(Optional.ofNullable(user));
-//      when(
-//          notificationRepository.getUnconfirmedWithCursor(userId, request.cursor(), request.after(),
-//              pageRequest)).thenReturn(expectNotifications);
-//
-//      //when
-//      CursorPageResponseDto<NotificationDto> allNotifications = notificationService.getAllNotifications(
-//          request, userId);
-//
-//      //then
-//      assertEquals(notification2.getId(), allNotifications.nextCursor());
-//      assertEquals(notification2.getCreatedAt(), allNotifications.nextAfter());
-//      assertTrue(allNotifications.hasNext());
-//
-//    }
-//
-//    @Test
-//    @DisplayName("성공: 다음 페이지 있고 커서 없음 (cursor not null / afterAt not null / limit 1)")
-//    void getNotificationHasNextTrueWithCursorSuccess() {
-//      //given
-//      UUID userId = user.getId();
-//
-//      List<Notification> expectNotifications = new ArrayList<>();
-//
-//      Notification notification1 = new Notification(user, interests.get(0).getId(),
-//          ResourceType.INTEREST, interests.get(0).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
-//      Notification notification2 = new Notification(user, interests.get(1).getId(),
-//          ResourceType.INTEREST, interests.get(1).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
-//
-//      UUID notificationId1 = UUID.randomUUID();
-//      UUID notificationId2 = UUID.randomUUID();
-//
-//      UUID cursor = notification2.getId();
-//      Instant afterAt = notification2.getCreatedAt();
-//
-//      NotificationSearchRequest request = new NotificationSearchRequest(cursor, afterAt, 1);
-//      PageRequest pageRequest = PageRequest.of(0, request.limit() + 1);
-//
-//      ReflectionTestUtils.setField(notification1, "id", notificationId1);
-//      ReflectionTestUtils.setField(notification2, "id", notificationId2);
-//
-//      expectNotifications.add(notification1);
-//      expectNotifications.add(notification2);
-//
-//      expectNotifications.sort(Comparator.comparing(Notification::getCreatedAt).reversed());
-//      expectNotifications.remove(expectNotifications.size() - 1 - request.limit());
-//
-//      when(userRepository.findById(userId)).thenReturn(Optional.ofNullable(user));
-//      when(notificationRepository.getUnconfirmedWithCursor(userId, cursor, afterAt,
-//          pageRequest)).thenReturn(expectNotifications);
-//
-//      //when
-//      CursorPageResponseDto<NotificationDto> allNotifications = notificationService.getAllNotifications(
-//          request, userId);
-//
-//      //then
-//      assertEquals(notification1.getId(), allNotifications.nextCursor());
-//      assertEquals(notification1.getCreatedAt(), allNotifications.nextAfter());
-//      assertFalse(allNotifications.hasNext());
-//
-//    }
+
+    @Test
+    @DisplayName("성공: 다음 페이지 있음 (cursor null / afterAt null / limit 1)")
+    void getNotificationHasNextTrueSuccess() {
+      //given
+
+      NotificationSearchRequest request = new NotificationSearchRequest(null, null, 1);
+
+      UUID userId = user.getId();
+
+      PageRequest pageRequest = PageRequest.of(0, request.limit() + 1);
+
+      List<Notification> expectNotifications = new ArrayList<>();
+
+      Notification notification1 = new Notification(user, interests.get(0).getId(),
+          ResourceType.INTEREST, interests.get(0).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
+      Notification notification2 = new Notification(user, interests.get(1).getId(),
+          ResourceType.INTEREST, interests.get(1).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
+
+      UUID notificationId1 = UUID.randomUUID();
+      UUID notificationId2 = UUID.randomUUID();
+
+      setField(notification1, "id", notificationId1);
+      setField(notification2, "id", notificationId2);
+
+      expectNotifications.add(notification1);
+      expectNotifications.add(notification2);
+
+      expectNotifications.sort(Comparator.comparing(Notification::getCreatedAt).reversed());
+
+      when(userRepository.findById(userId)).thenReturn(Optional.ofNullable(user));
+      when(
+          notificationRepository.getUnconfirmedWithCursor(userId, request.cursor(), request.after(),
+              pageRequest)).thenReturn(expectNotifications);
+
+      //when
+      CursorPageResponseDto<NotificationDto> allNotifications = notificationService.getAllNotifications(
+          request, userId);
+
+      //then
+      assertEquals(notification2.getId(), allNotifications.nextCursor());
+      assertEquals(notification2.getCreatedAt(), allNotifications.nextAfter());
+      assertTrue(allNotifications.hasNext());
+
+    }
+
+    @Test
+    @DisplayName("성공: 다음 페이지 있고 커서 없음 (cursor not null / afterAt not null / limit 1)")
+    void getNotificationHasNextTrueWithCursorSuccess() {
+      //given
+      UUID userId = user.getId();
+
+      List<Notification> expectNotifications = new ArrayList<>();
+
+      Notification notification1 = new Notification(user, interests.get(0).getId(),
+          ResourceType.INTEREST, interests.get(0).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
+      Notification notification2 = new Notification(user, interests.get(1).getId(),
+          ResourceType.INTEREST, interests.get(1).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
+
+      UUID notificationId1 = UUID.randomUUID();
+      UUID notificationId2 = UUID.randomUUID();
+
+      UUID cursor = notification2.getId();
+      Instant afterAt = notification2.getCreatedAt();
+
+      NotificationSearchRequest request = new NotificationSearchRequest(cursor, afterAt, 1);
+      PageRequest pageRequest = PageRequest.of(0, request.limit() + 1);
+
+      setField(notification1, "id", notificationId1);
+      setField(notification2, "id", notificationId2);
+
+      expectNotifications.add(notification1);
+      expectNotifications.add(notification2);
+
+      expectNotifications.sort(Comparator.comparing(Notification::getCreatedAt).reversed());
+      expectNotifications.remove(expectNotifications.size() - 1 - request.limit());
+
+      when(userRepository.findById(userId)).thenReturn(Optional.ofNullable(user));
+      when(notificationRepository.getUnconfirmedWithCursor(userId, cursor, afterAt,
+          pageRequest)).thenReturn(expectNotifications);
+
+      //when
+      CursorPageResponseDto<NotificationDto> allNotifications = notificationService.getAllNotifications(
+          request, userId);
+
+      //then
+      assertEquals(notification1.getId(), allNotifications.nextCursor());
+      assertEquals(notification1.getCreatedAt(), allNotifications.nextAfter());
+      assertFalse(allNotifications.hasNext());
+
+    }
   }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #146 
- #181 

## 🪐 작업 내용

### 1. 알림 테스트
- 알림 레포지토리 조회 메서드 테스트 구현
- 주석처리 되어있던 알림 테스트 코드 주석 해제 및 테스트 코드 에러 수정

### 2. 알림 엔티티
- createdAt 필드와 updatedAt필드의 어노테이션 수정

### 3. 관심사 유효성 검사 추가 및  에러 수정 
- 관심사 등록, 수정의 유효성 검사 추가
- 관심사 구독 시 이미 구독이 있으면 에러가 발생하는 문제 해결

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
