### PR TITLE
fix: 알림 생성시 created_at에 null 들어가던 오류 수정 및 테스트 코드 created_at 시간 조정

### DIFF
--- a/src/main/java/com/sprint/monew/domain/notification/Notification.java
+++ b/src/main/java/com/sprint/monew/domain/notification/Notification.java
@@ -67,6 +67,8 @@ public class Notification {
     this.resourceType = resourceType;
     this.content = content;
     this.confirmed = false;
+    this.createdAt = Instant.now();
+    this.updatedAt = this.createdAt;
   }
 
   public void confirm() {

--- a/src/test/java/com/sprint/monew/domain/notification/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/monew/domain/notification/NotificationServiceTest.java
@@ -24,6 +24,7 @@ import com.sprint.monew.domain.notification.repository.NotificationRepository;
 import com.sprint.monew.domain.user.User;
 import com.sprint.monew.domain.user.UserRepository;
 import com.sprint.monew.domain.user.exception.UserNotFoundException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -358,10 +359,10 @@ class NotificationServiceTest {
           ResourceType.INTEREST, interests.get(1).getName() + "와/과 관련된 기사가 " + 1 + "건 등록되었습니다.");
 
       notification1.setCreatedAt(Instant.now());
-      notification1.setUpdatedAt(Instant.now());
+      notification1.setUpdatedAt(notification1.getCreatedAt());
 
-      notification2.setCreatedAt(Instant.now());
-      notification2.setUpdatedAt(Instant.now());
+      notification2.setCreatedAt(Instant.now().plus(Duration.ofSeconds(1)));
+      notification2.setUpdatedAt(notification2.getCreatedAt());
 
       UUID notificationId1 = UUID.randomUUID();
       UUID notificationId2 = UUID.randomUUID();
@@ -407,10 +408,10 @@ class NotificationServiceTest {
       UUID notificationId2 = UUID.randomUUID();
 
       notification1.setCreatedAt(Instant.now());
-      notification1.setUpdatedAt(Instant.now());
+      notification1.setUpdatedAt(notification1.getCreatedAt());
 
-      notification2.setCreatedAt(Instant.now());
-      notification2.setUpdatedAt(Instant.now());
+      notification2.setCreatedAt(Instant.now().plus(Duration.ofSeconds(1)));
+      notification2.setUpdatedAt(notification2.getCreatedAt());
 
       setField(notification1, "id", notificationId1);
       setField(notification2, "id", notificationId2);


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- 테스트 객체를 거의 동시에 만들다 보니, 뒤에 밀리세컨드 부분이 잘려서 들어가는 것 때문에 테스트가 되었다가 안되었다 하는 문제 발생.따라서  나중에 만든 알림은 시간 좀 더 추가해서 테스트하는 것으로 수정
- 알림 생성 시 created_at, updated_at 필드 초기화로 재수정

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [] Label을 지정했나요?
