### PR TITLE
fix: 댓글 삭제시 댓글 개수가 줄어들지 않는 오류 수정

### DIFF
--- a/src/main/java/com/sprint/monew/domain/article/repository/ArticleRepositoryImpl.java
+++ b/src/main/java/com/sprint/monew/domain/article/repository/ArticleRepositoryImpl.java
@@ -39,7 +39,7 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
             article.publishDate, article.summary, comment.countDistinct(), viewAll.countDistinct(), viewMe.id.isNotNull())
         )
         .from(article)
-        .leftJoin(comment).on(comment.article.eq(article))
+        .leftJoin(comment).on(comment.article.eq(article).and(comment.deleted.isFalse()))
         .leftJoin(article.articleViews, viewAll)
         .leftJoin(article.articleViews, viewMe).on(viewMe.user.id.eq(userId))
         .leftJoin(article.articleInterests, articleInterest)

--- a/src/main/java/com/sprint/monew/domain/comment/like/Like.java
+++ b/src/main/java/com/sprint/monew/domain/comment/like/Like.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
@@ -22,7 +23,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @Setter
-@Table(name = "likes")
+@Table(name = "likes", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"comment_id", "user_id"})
+})
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -73,7 +73,8 @@ CREATE TABLE "likes"
     "id"         UUID PRIMARY KEY,
     "comment_id" UUID        NOT NULL,
     "user_id"    UUID        NOT NULL,
-    "created_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (comment_id, user_id)
 );
 
 CREATE TABLE "articles_interests"

--- a/src/test/resources/db/migration/V1__init_schema.sql
+++ b/src/test/resources/db/migration/V1__init_schema.sql
@@ -73,7 +73,8 @@ CREATE TABLE "likes"
     "id"         UUID PRIMARY KEY,
     "comment_id" UUID        NOT NULL,
     "user_id"    UUID        NOT NULL,
-    "created_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (comment_id, user_id)
 );
 
 CREATE TABLE "articles_interests"


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- 댓글 삭제시 댓글 개수가 줄어들지 않는 오류를 수정했습니다.
- like 엔티티와 테이블에 unique 제약 조건을 추가했습니다.
## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
