### PR TITLE
fix: 복구할 기사 자체가 없을 때, 예외 터지는 경우 수정

### DIFF
--- a/src/main/java/com/sprint/monew/domain/article/ArticleService.java
+++ b/src/main/java/com/sprint/monew/domain/article/ArticleService.java
@@ -125,14 +125,13 @@ public class ArticleService {
     log.info("Article Restore End");
     ExecutionContext jobContext = jobExecution.getExecutionContext();
     List<UUID> articleIds = (List<UUID>) jobContext.get(ARTICLE_IDS.getKey());
-    if (articleIds == null) {
-      throw new RuntimeException("ExecutionContext로부터 Article Ids를 가져오는 데 실패했습니다.");
-    }
+
+    long restoredArticleSize = articleIds == null ? 0 : articleIds.size();
 
     ArticleRestoreResultDto resultDto = new ArticleRestoreResultDto(
         Instant.now(),
         articleIds,
-        (long) articleIds.size()
+        restoredArticleSize
     );
     List<ArticleRestoreResultDto> result = List.of(resultDto);
     jobContext.remove(ARTICLE_IDS.getKey());


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
fix: 복구할 기사 자체가 없을 떄 articleIds가 null인 경우 예외처리 없애기

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
